### PR TITLE
FEATURE-4: provide Actor as optional module spec

### DIFF
--- a/apps/web/src/pages/ed/ns/actor.context.jsonld.ts
+++ b/apps/web/src/pages/ed/ns/actor.context.jsonld.ts
@@ -1,0 +1,7 @@
+import { createArtifactHandler } from '../../../lib/spec-artifacts';
+
+export const GET = createArtifactHandler(
+  import.meta.url,
+  '../../../../../../specs/ed/modules/actor/actor.context.jsonld',
+  'application/ld+json; charset=utf-8'
+);

--- a/apps/web/src/pages/ed/ns/actor.shape.ts
+++ b/apps/web/src/pages/ed/ns/actor.shape.ts
@@ -1,0 +1,7 @@
+import { createArtifactHandler } from '../../../lib/spec-artifacts';
+
+export const GET = createArtifactHandler(
+  import.meta.url,
+  '../../../../../../specs/ed/modules/actor/actor.shape.ttl',
+  'text/turtle; charset=utf-8'
+);

--- a/apps/web/src/pages/ed/ns/actor.ts
+++ b/apps/web/src/pages/ed/ns/actor.ts
@@ -1,0 +1,7 @@
+import { createArtifactHandler } from '../../../lib/spec-artifacts';
+
+export const GET = createArtifactHandler(
+  import.meta.url,
+  '../../../../../../specs/ed/modules/actor/actor.ttl',
+  'text/turtle; charset=utf-8'
+);

--- a/specs/ed/modules/actor/actor.context.jsonld
+++ b/specs/ed/modules/actor/actor.context.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@version": 1.1,
+
+    "ujgactor": "https://ujg.specs.openuji.org/ed/ns/actor#",
+    "actor": "https://ujg.specs.openuji.org/ed/ns/actor#",
+
+    "Actor": "ujgactor:Actor",
+
+    "responsibleActorRef": {
+      "@id": "ujgactor:responsibleActorRef",
+      "@type": "@id"
+    },
+    "eligibleActorRefs": {
+      "@id": "ujgactor:eligibleActorRefs",
+      "@type": "@id",
+      "@container": "@set"
+    }
+  }
+}

--- a/specs/ed/modules/actor/actor.shape.ttl
+++ b/specs/ed/modules/actor/actor.shape.ttl
@@ -1,0 +1,35 @@
+@prefix ujggraph: <https://ujg.specs.openuji.org/ed/ns/graph#> .
+@prefix ujgactor: <https://ujg.specs.openuji.org/ed/ns/actor#> .
+@prefix ujgactorshape: <https://ujg.specs.openuji.org/ed/ns/actor.shape#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+ujgactorshape:ActorShape a sh:NodeShape ;
+  sh:targetClass ujgactor:Actor ;
+  sh:nodeKind sh:IRI .
+
+ujgactorshape:ResponsibleActorHostShape a sh:NodeShape ;
+  sh:targetClass
+    ujggraph:Journey,
+    ujggraph:State,
+    ujggraph:CompositeState,
+    ujggraph:Transition,
+    ujggraph:OutgoingTransition,
+    ujggraph:OutgoingTransitionGroup ;
+  sh:nodeKind sh:IRI ;
+
+  sh:property [
+    sh:path ujgactor:responsibleActorRef ;
+    sh:class ujgactor:Actor ;
+    sh:nodeKind sh:IRI ;
+    sh:maxCount 1 ;
+  ] .
+
+ujgactorshape:EligibleActorHostShape a sh:NodeShape ;
+  sh:targetClass ujggraph:Transition, ujggraph:OutgoingTransition ;
+  sh:nodeKind sh:IRI ;
+
+  sh:property [
+    sh:path ujgactor:eligibleActorRefs ;
+    sh:class ujgactor:Actor ;
+    sh:nodeKind sh:IRI ;
+  ] .

--- a/specs/ed/modules/actor/actor.ttl
+++ b/specs/ed/modules/actor/actor.ttl
@@ -1,0 +1,41 @@
+@prefix ujg: <https://ujg.specs.openuji.org/ed/ns/core#> .
+@prefix ujggraph: <https://ujg.specs.openuji.org/ed/ns/graph#> .
+@prefix ujgactor: <https://ujg.specs.openuji.org/ed/ns/actor#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+
+<https://ujg.specs.openuji.org/ed/ns/actor#> a owl:Ontology ;
+  rdfs:label "UJG Actor Editor's Draft Vocabulary"@en ;
+  dct:description "UJG Actor ontology declaration" .
+
+### Classes
+
+ujgactor:Actor a owl:Class ;
+  rdfs:subClassOf ujg:Node .
+
+### Properties
+
+ujgactor:responsibleActorRef a owl:ObjectProperty ;
+  rdfs:domain [
+    a owl:Class ;
+    owl:unionOf (
+      ujggraph:Journey
+      ujggraph:State
+      ujggraph:CompositeState
+      ujggraph:Transition
+      ujggraph:OutgoingTransition
+      ujggraph:OutgoingTransitionGroup
+    )
+  ] ;
+  rdfs:range ujgactor:Actor .
+
+ujgactor:eligibleActorRefs a owl:ObjectProperty ;
+  rdfs:domain [
+    a owl:Class ;
+    owl:unionOf (
+      ujggraph:Transition
+      ujggraph:OutgoingTransition
+    )
+  ] ;
+  rdfs:range ujgactor:Actor .

--- a/specs/ed/modules/actor/config.json
+++ b/specs/ed/modules/actor/config.json
@@ -1,0 +1,39 @@
+{
+    "id": "modules/actor",
+    "title": "Actor",
+    "maturityLevel": "incubating",
+    "baseUrl": "${SPEC_BASE_URL}/ed",
+    "deps": [
+        "graph"
+    ],
+    "custom": {
+        "family": "module",
+        "order": 46
+    },
+    "respec": {
+        "noConformance": true,
+        "modificationDate": "${SPEC_MODIFICATION_DATE}",
+        "group": {
+            "name": "User Journal Graph Community Group",
+            "url": "https://www.w3.org/community/ujg/"
+        },
+        "repository": "https://github.com/openuji/spec-ujg/blob/main/specs/ed/modules/actor/index.md",
+        "editors": [
+            {
+                "name": "Seva Dolgopolov",
+                "w3cid": "169225"
+            }
+        ],
+        "license": "W3C-Software-and-Document",
+        "localBiblio": {
+            "UJG Core": {
+                "title": "UJG Core",
+                "url": "/ed/core"
+            },
+            "UJG Graph": {
+                "title": "UJG Graph",
+                "url": "/ed/graph"
+            }
+        }
+    }
+}

--- a/specs/ed/modules/actor/index.md
+++ b/specs/ed/modules/actor/index.md
@@ -1,0 +1,184 @@
+## Overview
+
+This optional module defines a minimal graph-native vocabulary for attaching actor responsibility
+and eligibility metadata to foundational Graph nodes.
+
+Without an actor primitive, implementations tend to hide responsibility, approval eligibility, or
+participant metadata in opaque payloads and extensions. That makes governance and human-in-the-loop
+questions difficult to validate, query, or preserve across tools.
+
+This first version is intentionally small. It declares `Actor` nodes and two references for Graph
+metadata. It does not define identity systems, accounts, enforcement, provenance, or runtime
+attribution.
+
+## Normative Artifacts
+
+This module is published through the following artifacts:
+
+- `actor.ttl`: ontology, published at `https://ujg.specs.openuji.org/ed/ns/actor`
+- `actor.context.jsonld`: JSON-LD term mappings, published at `https://ujg.specs.openuji.org/ed/ns/actor.context.jsonld`
+- `actor.shape.ttl`: SHACL validation rules, published at `https://ujg.specs.openuji.org/ed/ns/actor.shape`
+
+Examples in this page compose the shared baseline context `https://ujg.specs.openuji.org/ed/ns/context.jsonld`
+with the Actor context.
+
+## Terminology
+
+- <dfn>Actor</dfn>: An addressable participant, role-like entity, system, organization, or other
+  responsible party represented as a Core `Node`.
+- <dfn>Responsible actor</dfn>: The actor responsible for ownership or stewardship of a Graph node.
+- <dfn>Eligible actor</dfn>: An actor described as eligible to perform, approve, or trigger a
+  transition-like Graph edge.
+
+## Attachment Model
+
+The module introduces two interoperable attachments:
+
+- `actor:responsibleActorRef` links an allowed Graph node to one [=Actor=].
+- `actor:eligibleActorRefs` links an allowed transition-like Graph edge to one or more [=Actor|Actors=].
+
+The allowed host nodes are intentionally limited.
+
+`responsibleActorRef` is allowed on:
+
+- [=Journey=]
+- [=State=]
+- [=CompositeState=]
+- [=Transition=]
+- [=OutgoingTransition=]
+- [=OutgoingTransitionGroup=]
+
+`eligibleActorRefs` is allowed on:
+
+- [=Transition=]
+- [=OutgoingTransition=]
+
+A Graph node without Actor references remains fully valid and traversable. Consumers MAY ignore this
+module and still process the graph.
+
+## Non-Goals
+
+Actor does not define:
+
+- authentication
+- authorization enforcement
+- IAM groups
+- user accounts
+- PII fields
+- org charts
+- legal accountability
+- runtime access-control APIs
+- delegation workflows
+- cryptographic signing
+- traversal semantics
+- transition eligibility evaluation
+
+Actor v0 also does not attach actors to runtime nodes, journey stacks, experience annotations,
+opaque extension payloads, or nodes defined by other optional modules.
+
+## Runtime Attribution Research Notice
+
+Runtime actor attribution is intentionally not standardized in Actor v0.
+
+Open questions include whether observed performer, uploader, subject, or evidence identity belongs
+on runtime events, journey stack frames, payload evidence, a provenance or audit module, or a future
+runtime-observation module. Until that is standardized, runtime actor attribution should remain
+implementation-specific or be carried in extensions.
+
+## Ontology {data-cop-concept="ontology"}
+
+The normative Actor ontology is defined below and is published at
+`https://ujg.specs.openuji.org/ed/ns/actor`.
+
+:::include ./actor.ttl :::
+
+## JSON-LD Context {data-cop-concept="jsonld-context"}
+
+The normative Actor JSON-LD context is defined below and is published at
+`https://ujg.specs.openuji.org/ed/ns/actor.context.jsonld`.
+
+:::include ./actor.context.jsonld :::
+
+## Validation {data-cop-concept="validation"}
+
+The normative Actor SHACL shape is defined below and is published at
+`https://ujg.specs.openuji.org/ed/ns/actor.shape`.
+
+:::include ./actor.shape.ttl :::
+
+The rules below define the remaining module semantics beyond the structural constraints captured by
+the SHACL shape.
+
+1. **Graph metadata only:** Actor references describe Graph responsibility and eligibility metadata.
+   They MUST NOT create hidden graph edges or change traversal behavior.
+2. **Responsibility meaning:** `responsibleActorRef` identifies ownership or stewardship, not legal
+   accountability.
+3. **Eligibility meaning:** `eligibleActorRefs` describes intended actor eligibility, not
+   authorization enforcement.
+4. **Graceful degradation:** Consumers that do not implement this module MAY ignore Actor semantics,
+   but SHOULD preserve recognized JSON-LD data during read-transform-write when possible.
+5. **Host boundary:** Actor v0 MUST NOT be interpreted as defining actor attachments for nodes
+   outside the allowed Graph host classes.
+
+## Minimal Example
+
+```json
+{
+  "@context": [
+    "https://ujg.specs.openuji.org/ed/ns/context.jsonld",
+    "https://ujg.specs.openuji.org/ed/ns/actor.context.jsonld"
+  ],
+  "@id": "https://example.com/ujg/actor/physical-ai-decision.jsonld",
+  "@type": "UJGDocument",
+  "specVersion": "1.0",
+  "nodes": [
+    {
+      "@id": "urn:ujg:actor:physical-ai-system",
+      "@type": "Actor",
+      "label": "Physical AI System"
+    },
+    {
+      "@id": "urn:ujg:actor:production-engineer",
+      "@type": "Actor",
+      "label": "Production Engineer"
+    },
+    {
+      "@id": "urn:ujg:actor:supervisor",
+      "@type": "Actor",
+      "label": "Supervisor"
+    },
+    {
+      "@id": "urn:ujg:journey:physical-ai-review",
+      "@type": "Journey",
+      "startState": "urn:ujg:state:engineer-approval-required",
+      "stateRefs": [
+        "urn:ujg:state:engineer-approval-required",
+        "urn:ujg:state:decision-approved"
+      ],
+      "transitionRefs": ["urn:ujg:transition:approve-ai-decision"],
+      "responsibleActorRef": "urn:ujg:actor:production-engineer"
+    },
+    {
+      "@id": "urn:ujg:state:engineer-approval-required",
+      "@type": "State",
+      "label": "Engineer approval required",
+      "responsibleActorRef": "urn:ujg:actor:production-engineer"
+    },
+    {
+      "@id": "urn:ujg:state:decision-approved",
+      "@type": "State",
+      "label": "Decision approved"
+    },
+    {
+      "@id": "urn:ujg:transition:approve-ai-decision",
+      "@type": "Transition",
+      "from": "urn:ujg:state:engineer-approval-required",
+      "to": "urn:ujg:state:decision-approved",
+      "eligibleActorRefs": [
+        "urn:ujg:actor:production-engineer",
+        "urn:ujg:actor:supervisor"
+      ]
+    }
+  ]
+}
+```


### PR DESCRIPTION
## Summary

This PR introduces an incubating optional **Actor** module for UJG.

The module defines a minimal graph-native vocabulary for attaching actor responsibility and eligibility metadata to foundational Graph nodes. It is motivated by governance and human-in-the-loop use cases where UJG needs to describe who owns, reviews, approves, or may trigger parts of a journey without turning UJG into an identity, authorization, or IAM system.

This is especially relevant for #4, where Physical AI systems may propose or perform operational actions, while humans remain responsible for approval, override, and later audit/review.

## What changed

Adds a new optional module:

* `specs/ed/modules/actor/index.md`
* `specs/ed/modules/actor/config.json`
* `specs/ed/modules/actor/actor.ttl`
* `specs/ed/modules/actor/actor.context.jsonld`
* `specs/ed/modules/actor/actor.shape.ttl`


## Module scope

Actor v0 intentionally stays small.

It defines:

* `Actor`
* `responsibleActorRef`
* `eligibleActorRefs`

The module allows UJG graphs to express, for example:

* this journey is stewarded by a production engineer
* this state is owned by a responsible role
* this transition may be triggered or approved by one or more actors

## Non-goals

This PR does **not** define:

* authentication
* authorization enforcement
* IAM groups
* user accounts
* PII fields
* org charts
* legal accountability
* runtime access-control APIs
* delegation workflows
* cryptographic signing
* traversal semantics
* transition eligibility evaluation

It also does not standardize runtime actor attribution yet. Runtime performer/evidence attribution remains an open research topic for a future module or extension.

## Design rationale

Without an actor primitive, implementations are likely to hide responsibility, approval eligibility, or participant metadata inside opaque payloads and extensions. That makes governance-oriented journeys harder to validate, query, preserve, and exchange across tools.

Actor keeps this metadata graph-native while preserving graceful degradation: consumers that do not implement the module can ignore Actor semantics and still process the graph.

## Relationship to #4

Issue #4 raises the Physical AI / human-in-the-loop governance case:

* AI proposes an action
* operator or engineer reviews it
* supervisor may override it
* QA / compliance may later review the evidence

This PR does not solve the full runtime evidence problem, but it introduces the missing graph-level primitive needed to describe responsible and eligible participants in those journeys.

## Review focus

I would especially like feedback on:

* whether `Actor` is the right name for the primitive
* whether `responsibleActorRef` and `eligibleActorRefs` are the right first two properties
* whether Actor v0 should stay limited to Graph nodes
* whether runtime actor attribution should remain out of scope for this first version
* whether the allowed host classes are too broad, too narrow, or correctly scoped

## Checklist

* [x] Adds module documentation
* [x] Adds ontology artifact
* [x] Adds JSON-LD context artifact
* [x] Adds SHACL shape artifact
* [x] Keeps the module optional and incubating
* [x] Avoids identity, IAM, authorization, and runtime attribution semantics
