### PR TITLE
define graph journey exit semantic

### DIFF
--- a/specs/ed/graph/content-manifest.json
+++ b/specs/ed/graph/content-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
   "publishedAt": "2026-02-14T16:41:32.000Z",
-  "updatedAt": "2026-06-09T16:36:36.009Z",
-  "contentHash": "sha256:1a95abd38c9e0f27761fb2620310b2c850966526e36a30bf1cd73a9035aa3ad3"
+  "updatedAt": "2026-06-10T15:16:42.222Z",
+  "contentHash": "sha256:767e6b5e623bfa662b6b436dac216d33bd10cc0374fa2b847a122fcd2db81666"
 }

--- a/specs/ed/graph/graph.context.jsonld
+++ b/specs/ed/graph/graph.context.jsonld
@@ -8,6 +8,7 @@
     "State": "ujggraph:State",
     "CompositeState": "ujggraph:CompositeState",
     "Transition": "ujggraph:Transition",
+    "JourneyExit": "ujggraph:JourneyExit",
     "OutgoingTransition": "ujggraph:OutgoingTransition",
     "OutgoingTransitionGroup": "ujggraph:OutgoingTransitionGroup",
 
@@ -30,6 +31,11 @@
       "@type": "@id",
       "@container": "@set"
     },
+    "exitRefs": {
+      "@id": "ujggraph:exitRefs",
+      "@type": "@id",
+      "@container": "@set"
+    },
     "outgoingTransitionGroupRefs": {
       "@id": "ujggraph:outgoingTransitionGroupRefs",
       "@type": "@id",
@@ -43,8 +49,16 @@
       "@id": "ujggraph:to",
       "@type": "@id"
     },
+    "exitRef": {
+      "@id": "ujggraph:exitRef",
+      "@type": "@id"
+    },
     "subjourneyId": {
       "@id": "ujggraph:subjourneyId",
+      "@type": "@id"
+    },
+    "exitStateRef": {
+      "@id": "ujggraph:exitStateRef",
       "@type": "@id"
     },
     "outgoingTransitionRefs": {

--- a/specs/ed/graph/graph.shape.ttl
+++ b/specs/ed/graph/graph.shape.ttl
@@ -36,6 +36,12 @@ ujggraphshape:JourneyShape a sh:NodeShape ;
   ] ;
 
   sh:property [
+    sh:path ujggraph:exitRefs ;
+    sh:class ujggraph:JourneyExit ;
+    sh:nodeKind sh:IRI ;
+  ] ;
+
+  sh:property [
     sh:path ujggraph:outgoingTransitionGroupRefs ;
     sh:class ujggraph:OutgoingTransitionGroup ;
     sh:nodeKind sh:IRI ;
@@ -69,6 +75,187 @@ ujggraphshape:JourneyShape a sh:NodeShape ;
         FILTER (NOT EXISTS {
           $this ujggraph:stateRefs ?to .
         })
+      }
+    """ ;
+  ] ;
+
+  sh:sparql [
+    a sh:SPARQLConstraint ;
+    sh:message "A JourneyExit in exitRefs has an exitStateRef that is not listed in this journey's stateRefs." ;
+    sh:select """
+      SELECT $this ?exit ?exitState
+      WHERE {
+        $this ujggraph:exitRefs ?exit .
+        ?exit ujggraph:exitStateRef ?exitState .
+
+        FILTER (NOT EXISTS {
+          $this ujggraph:stateRefs ?exitState .
+        })
+      }
+    """ ;
+  ] ;
+
+  sh:sparql [
+    a sh:SPARQLConstraint ;
+    sh:message "A JourneyExit must not be listed in the exitRefs of more than one journey." ;
+    sh:select """
+      SELECT $this ?exit ?otherJourney
+      WHERE {
+        $this ujggraph:exitRefs ?exit .
+        ?otherJourney ujggraph:exitRefs ?exit .
+        FILTER ($this != ?otherJourney)
+      }
+    """ ;
+  ] ;
+
+  sh:sparql [
+    a sh:SPARQLConstraint ;
+    sh:message "A journey must not list more than one JourneyExit with the same exitStateRef." ;
+    sh:select """
+      SELECT $this ?exitState ?exit ?otherExit
+      WHERE {
+        $this ujggraph:exitRefs ?exit, ?otherExit .
+        ?exit ujggraph:exitStateRef ?exitState .
+        ?otherExit ujggraph:exitStateRef ?exitState .
+        FILTER (?exit != ?otherExit)
+      }
+    """ ;
+  ] ;
+
+  sh:sparql [
+    a sh:SPARQLConstraint ;
+    sh:message "A state referenced by JourneyExit.exitStateRef must not be used as the from value of a transition listed in the same journey." ;
+    sh:select """
+      SELECT $this ?exit ?exitState ?transition
+      WHERE {
+        $this ujggraph:exitRefs ?exit ;
+              ujggraph:transitionRefs ?transition .
+        ?exit ujggraph:exitStateRef ?exitState .
+        ?transition ujggraph:from ?exitState .
+      }
+    """ ;
+  ] ;
+
+  sh:sparql [
+    a sh:SPARQLConstraint ;
+    sh:message "A transition with exitRef must have a from value listed in the enclosing journey's stateRefs." ;
+    sh:select """
+      SELECT $this ?transition ?from
+      WHERE {
+        $this ujggraph:transitionRefs ?transition .
+        ?transition ujggraph:exitRef ?exit ;
+                    ujggraph:from ?from .
+
+        FILTER (NOT EXISTS {
+          $this ujggraph:stateRefs ?from .
+        })
+      }
+    """ ;
+  ] ;
+
+  sh:sparql [
+    a sh:SPARQLConstraint ;
+    sh:message "A transition with exitRef must have a from value that references a CompositeState." ;
+    sh:select """
+      SELECT $this ?transition ?from
+      WHERE {
+        $this ujggraph:transitionRefs ?transition .
+        ?transition ujggraph:exitRef ?exit ;
+                    ujggraph:from ?from .
+
+        FILTER (NOT EXISTS {
+          ?from a ujggraph:CompositeState .
+        })
+      }
+    """ ;
+  ] ;
+
+  sh:sparql [
+    a sh:SPARQLConstraint ;
+    sh:message "The CompositeState used as from by a transition with exitRef must declare exactly one subjourneyId." ;
+    sh:select """
+      SELECT $this ?transition ?from
+      WHERE {
+        $this ujggraph:transitionRefs ?transition .
+        ?transition ujggraph:exitRef ?exit ;
+                    ujggraph:from ?from .
+
+        FILTER (
+          NOT EXISTS { ?from ujggraph:subjourneyId ?subjourney . }
+          || EXISTS {
+            ?from ujggraph:subjourneyId ?subjourneyA, ?subjourneyB .
+            FILTER (?subjourneyA != ?subjourneyB)
+          }
+        )
+      }
+    """ ;
+  ] ;
+
+  sh:sparql [
+    a sh:SPARQLConstraint ;
+    sh:message "The subjourneyId of the CompositeState used by a transition with exitRef must resolve to a Journey." ;
+    sh:select """
+      SELECT $this ?transition ?from ?subjourney
+      WHERE {
+        $this ujggraph:transitionRefs ?transition .
+        ?transition ujggraph:exitRef ?exit ;
+                    ujggraph:from ?from .
+        ?from ujggraph:subjourneyId ?subjourney .
+
+        FILTER (NOT EXISTS {
+          ?subjourney a ujggraph:Journey .
+        })
+      }
+    """ ;
+  ] ;
+
+  sh:sparql [
+    a sh:SPARQLConstraint ;
+    sh:message "The exitRef of a parent transition must be listed in the exitRefs of the child journey referenced by the from CompositeState." ;
+    sh:select """
+      SELECT $this ?transition ?from ?subjourney ?exit
+      WHERE {
+        $this ujggraph:transitionRefs ?transition .
+        ?transition ujggraph:exitRef ?exit ;
+                    ujggraph:from ?from .
+        ?from ujggraph:subjourneyId ?subjourney .
+
+        FILTER (NOT EXISTS {
+          ?subjourney ujggraph:exitRefs ?exit .
+        })
+      }
+    """ ;
+  ] ;
+
+  sh:sparql [
+    a sh:SPARQLConstraint ;
+    sh:message "A transition with exitRef must have a to value listed in the enclosing journey's stateRefs." ;
+    sh:select """
+      SELECT $this ?transition ?to
+      WHERE {
+        $this ujggraph:transitionRefs ?transition .
+        ?transition ujggraph:exitRef ?exit ;
+                    ujggraph:to ?to .
+
+        FILTER (NOT EXISTS {
+          $this ujggraph:stateRefs ?to .
+        })
+      }
+    """ ;
+  ] ;
+
+  sh:sparql [
+    a sh:SPARQLConstraint ;
+    sh:message "A journey must not contain more than one transition with the same from value and the same exitRef value." ;
+    sh:select """
+      SELECT $this ?from ?exit ?transition ?otherTransition
+      WHERE {
+        $this ujggraph:transitionRefs ?transition, ?otherTransition .
+        ?transition ujggraph:from ?from ;
+                    ujggraph:exitRef ?exit .
+        ?otherTransition ujggraph:from ?from ;
+                         ujggraph:exitRef ?exit .
+        FILTER (?transition != ?otherTransition)
       }
     """ ;
   ] .
@@ -141,6 +328,31 @@ ujggraphshape:TransitionShape a sh:NodeShape ;
     sh:path ujggraph:label ;
     sh:datatype xsd:string ;
     sh:maxCount 1 ;
+  ] ;
+
+  sh:property [
+    sh:path ujggraph:exitRef ;
+    sh:class ujggraph:JourneyExit ;
+    sh:nodeKind sh:IRI ;
+    sh:maxCount 1 ;
+  ] .
+
+ujggraphshape:JourneyExitShape a sh:NodeShape ;
+  sh:targetClass ujggraph:JourneyExit ;
+  sh:nodeKind sh:IRI ;
+
+  sh:property [
+    sh:path ujggraph:label ;
+    sh:datatype xsd:string ;
+    sh:maxCount 1 ;
+  ] ;
+
+  sh:property [
+    sh:path ujggraph:exitStateRef ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:nodeKind sh:IRI ;
+    sh:node ujggraphshape:StateLikeShape ;
   ] .
 
 ujggraphshape:OutgoingTransitionShape a sh:NodeShape ;
@@ -169,4 +381,4 @@ ujggraphshape:OutgoingTransitionGroupShape a sh:NodeShape ;
     sh:class ujggraph:OutgoingTransition ;
     sh:nodeKind sh:IRI ;
     sh:minCount 1 ;
-  ] . 
+  ] .

--- a/specs/ed/graph/graph.ttl
+++ b/specs/ed/graph/graph.ttl
@@ -24,6 +24,11 @@ ujggraph:CompositeState a owl:Class ;
 ujggraph:Transition a owl:Class ;
   rdfs:subClassOf ujg:Node .
 
+ujggraph:JourneyExit a owl:Class ;
+  rdfs:subClassOf ujg:Node ;
+  rdfs:label "Journey Exit" ;
+  rdfs:comment "An exported exit contract for a journey, bound to a boundary state local to that journey." .
+
 ujggraph:OutgoingTransition a owl:Class ;
   rdfs:subClassOf ujg:Node .
 
@@ -51,6 +56,12 @@ ujggraph:transitionRefs a owl:ObjectProperty ;
   rdfs:domain ujggraph:Journey ;
   rdfs:range ujggraph:Transition .
 
+ujggraph:exitRefs a owl:ObjectProperty ;
+  rdfs:domain ujggraph:Journey ;
+  rdfs:range ujggraph:JourneyExit ;
+  rdfs:label "exit refs" ;
+  rdfs:comment "References the exported exits declared by a journey." .
+
 ujggraph:outgoingTransitionGroupRefs a owl:ObjectProperty ;
   rdfs:domain ujggraph:Journey ;
   rdfs:range ujggraph:OutgoingTransitionGroup .
@@ -62,9 +73,21 @@ ujggraph:from a owl:ObjectProperty ;
 ujggraph:to a owl:ObjectProperty ;
   rdfs:range ujggraph:State .
 
+ujggraph:exitRef a owl:ObjectProperty ;
+  rdfs:domain ujggraph:Transition ;
+  rdfs:range ujggraph:JourneyExit ;
+  rdfs:label "exit ref" ;
+  rdfs:comment "Identifies the exported JourneyExit reached by the child journey of a CompositeState used as the transition's from value. This property is not a transition endpoint." .
+
 ujggraph:subjourneyId a owl:ObjectProperty ;
   rdfs:domain ujggraph:CompositeState ;
   rdfs:range ujggraph:Journey .
+
+ujggraph:exitStateRef a owl:ObjectProperty ;
+  rdfs:domain ujggraph:JourneyExit ;
+  rdfs:range ujggraph:State ;
+  rdfs:label "exit state ref" ;
+  rdfs:comment "References the boundary state local to the journey that declares this JourneyExit." .
 
 ujggraph:outgoingTransitionRefs a owl:ObjectProperty ;
   rdfs:domain ujggraph:OutgoingTransitionGroup ;

--- a/specs/ed/graph/index.md
+++ b/specs/ed/graph/index.md
@@ -1,6 +1,6 @@
 ## Overview
 
-This module defines the vocabulary for **intended** user flow. It extends [[UJG Core]] to support structured, interactive graphs with composition via sub-journey references, organization tags, and reusable outgoing navigation patterns.
+This module defines the vocabulary for **intended** user flow. It extends [[UJG Core]] to support structured, interactive graphs with composition via sub-journey references, exported exits from nested journeys, organization tags, and reusable outgoing navigation patterns.
 
 ## Normative Artifacts
 
@@ -18,7 +18,9 @@ Examples in this page use an explicit context array composed from the published 
 - <dfn>State</dfn>: A discrete node in the experience (e.g., a screen, modal).
 - <dfn>Transition</dfn>: A directed edge between two states.
 - <dfn>CompositeState</dfn>: A state that encapsulates another [=Journey=] (sub-journey).
-- <dfn>OutgoingTransition</dfn>: A one way edge pointing to a next possible [=State=]
+- <dfn>JourneyExit</dfn>: An exported boundary contract declared by a [=Journey=].
+- <dfn>Boundary state</dfn>: A [=State=] or [=CompositeState=] listed in a [=Journey=]'s `stateRefs` that represents a completed outcome of that journey.
+- <dfn>OutgoingTransition</dfn>: A one way edge pointing to a next possible [=State=].
 - <dfn>OutgoingTransitionGroup</dfn>: A reusable set of outgoing transitions that a Consumer can treat as present on multiple states (e.g., global nav).
 
 ---
@@ -32,7 +34,6 @@ Examples in this page use an explicit context array composed from the published 
 ```mermaid
 graph LR
     A[State: Product] -->|Transition: Add| B[State: Cart]
-
 ```
 
 ## Composition (CompositeState) {data-cop-concept="composition"}
@@ -49,12 +50,108 @@ graph LR
       s1[Shipping] --> s2[Payment]
     end
     C --> E[Exit]
-
 ```
 
 The structural definition of [=CompositeState=] and `subjourneyId` is normative in the ontology and validation artifacts. This section defines only how consumers interpret that structure as nested or zoomable journey composition.
 
 <spec-statement>A [=CompositeState=] **MUST** reference its nested graph through `subjourneyId` and **MUST NOT** list child states directly with `stateRefs`.</spec-statement>
+
+---
+
+## Exported Journey Exits {data-cop-concept="journey-exits"}
+
+A [=JourneyExit=] lets a child [=Journey=] export one or more named boundary exits. A parent [=Journey=] can then map each exported exit to a parent-local [=Transition=] from the [=CompositeState=] that references the child journey.
+
+A [=JourneyExit=] identifies one local [=Boundary state=] of the declaring journey using `exitStateRef`. It allows an enclosing parent journey to distinguish which exported outcome of a nested child journey was reached without allowing the parent journey to reference child states directly.
+
+`exitRef` is a mapping property on a parent transition. It is not a transition endpoint. A transition's `from` and `to` values remain local to the enclosing journey.
+
+### Visual Model
+
+```mermaid
+graph LR
+    P1[Parent: SearchPage CompositeState] -->|exitRef: submitted| P2[Parent: Results]
+
+    subgraph Child [Child Journey: SearchPage]
+      direction LR
+      C1[Search form] --> C2[Submitted boundary state]
+    end
+
+    P1 -. subjourneyId .-> Child
+    C2 -. exitStateRef .-> X[JourneyExit: submitted]
+```
+
+### Conceptual Model
+
+<spec-statement>
+1. A [=Journey=] **MAY** declare `exitRefs`.
+2. Each value of `exitRefs` **MUST** reference a [=JourneyExit=].
+3. A [=JourneyExit=] **MUST** declare exactly one `exitStateRef`.
+4. The `exitStateRef` of a [=JourneyExit=] declared by a journey **MUST** reference a [=State=] or [=CompositeState=] listed in that same journey's `stateRefs`.
+5. A [=JourneyExit=] **MUST** be declared by no more than one [=Journey=].
+6. A [=Journey=] **MUST NOT** list more than one [=JourneyExit=] with the same `exitStateRef`.
+</spec-statement>
+
+<spec-statement>
+1. A [=Transition=] **MAY** declare `exitRef`.
+2. A [=Transition=] **MUST NOT** declare more than one `exitRef`.
+3. A [=Transition=] with `exitRef` **MUST** have a `from` value that references a [=CompositeState=].
+4. The [=CompositeState=] referenced by `from` **MUST** declare exactly one `subjourneyId`.
+5. The `subjourneyId` value **MUST** resolve to a [=Journey=].
+6. The `exitRef` value **MUST** be listed in the `exitRefs` of the journey referenced by the `from` composite state's `subjourneyId`.
+7. `exitRef` **MUST NOT** weaken, replace, or bypass local transition endpoint validation.
+8. A transition's `from` and `to` values **MUST** continue to reference states or composite states listed in the enclosing journey's `stateRefs`.
+9. A parent transition **MUST NOT** directly reference a child journey's state as `from`, `to`, or through any child-state-specific transition property.
+10. A journey **MUST NOT** contain more than one transition with the same `from` value and the same `exitRef` value.
+</spec-statement>
+
+### Boundary States
+
+<spec-statement>
+1. A state referenced by `JourneyExit.exitStateRef` **MUST** be a [=Boundary state=] for the declaring journey.
+2. A state referenced by `JourneyExit.exitStateRef` **MUST NOT** be used as the `from` value of another [=Transition=] listed in the same journey's `transitionRefs`.
+3. Outgoing transition group injection **MUST NOT** create effective outgoing transitions from a state referenced by `JourneyExit.exitStateRef` in the same journey.
+4. A [=JourneyExit=] **MUST NOT** be used for ordinary internal child transitions. Internal movement inside the child journey **MUST** continue to use normal [=Transition=] resources.
+5. Runtime observations, user actions, form values, clicked elements, submitted values, selected values, analytics facts, or other runtime facts **MUST NOT** be modeled in the Graph module through [=JourneyExit=]. Runtime facts remain outside the Graph module.
+6. If `exitStateRef` references a [=CompositeState=], the declaring journey reaches that [=JourneyExit=] only when interpretation of that composite state has completed according to the exported-exit processing model.
+</spec-statement>
+
+### Processing Model
+
+<spec-statement>
+When a Consumer enters a [=CompositeState=], it **MAY** resolve the composite state's `subjourneyId` and interpret the referenced child [=Journey=].
+
+If interpretation of the child journey reaches a state that is the `exitStateRef` of a [=JourneyExit=] listed in that child journey's `exitRefs`, that [=JourneyExit=] becomes the exported exit of the child journey.
+
+If more than one [=JourneyExit=] listed by the same child journey has the same `exitStateRef`, the graph is invalid. A Consumer **MUST NOT** choose one arbitrarily.
+
+The enclosing journey may then continue only by taking a parent transition whose:
+
+1. `from` value is the active parent-local [=CompositeState=]; and
+2. `exitRef` value is the exported [=JourneyExit=].
+
+If exactly one matching parent transition exists, the Consumer **MAY** continue to that transition's parent-local `to` state.
+
+If no matching parent transition exists, the Consumer **MUST NOT** synthesize an implicit parent transition.
+
+If more than one matching parent transition exists, the graph is invalid. A Consumer **MUST NOT** choose one arbitrarily.
+
+A Consumer **MUST NOT** treat `exitRef` as a replacement for `from` or `to`.
+
+A Consumer **MUST NOT** follow a parent transition whose `from` or `to` value is not listed in the enclosing journey's `stateRefs`.
+
+A Consumer **MUST NOT** treat a parent transition without `exitRef` as a fallback for an exported child journey exit.
+</spec-statement>
+
+<spec-statement>If a child journey declares `exitRefs` and reaches one of those exported exits, parent continuation for that exported exit **MUST** use a matching parent transition with `exitRef`. A parent transition without `exitRef` **MUST NOT** be treated as a fallback match for an exported child journey exit.</spec-statement>
+
+### Authoring Guidance
+
+Use [=JourneyExit=] when a nested journey has multiple explicit boundary outcomes that the parent journey needs to distinguish. For example, a search form child journey may export `submitted`, `cancelled`, and `emptyQuery`; the parent journey can then map each exported exit to a different parent-level transition without referring directly to child states.
+
+Do not use [=JourneyExit=] for ordinary transitions inside the child journey. Use normal child [=Transition=] resources for internal child movement.
+
+Do not use [=JourneyExit=] when the parent transition intentionally treats the composite state as an undifferentiated whole. In that case, a normal transition from the [=CompositeState=] without `exitRef` remains sufficient, and the child journey should not require exported exits for that parent-level behavior.
 
 ---
 
@@ -68,47 +165,41 @@ The structural definition of [=OutgoingTransitionGroup=] and [=OutgoingTransitio
 
 ```mermaid
 graph TD
-    %% Global Destinations defined in the Group
     subgraph Global [Global Navigation]
       direction LR
       H[Target: Home]
       P[Target: Profile]
     end
 
-    %% The Standard User Journey
     subgraph Flow [Checkout User Journey]
       direction LR
       S1[State: Shipping] -->|Explicit| S2[State: Payment]
     end
 
-    %% The Injection Logic (Applies to ALL states in Flow)
     S1 -.->|Outgoing| H
     S1 -.->|Outgoing| P
     S2 -.->|Outgoing| H
     S2 -.->|Outgoing| P
 
-    %% Styling for clarity
     linkStyle 1,2,3,4 stroke-dasharray: 5 5, stroke:green, color:green;
-
 ```
 
 ### Processing Model (Injection)
 
 <spec-statement>
 When a Consumer loads a [=Journey=] referencing `outgoingTransitionGroupRefs`:
-1. **Resolution:**
-  * The Consumer **MUST** resolve each referenced [=OutgoingTransitionGroup=]
-  * The Consumer **MUST** resolve each `outgoingTransitionRefs` entry to an [=OutgoingTransition=].
-2. **Iteration:** The Consumer **MUST** iterate over every [=State=] and [=CompositeState=] ID in `stateRefs`.
+1. **Resolution:** The Consumer **MUST** resolve each referenced [=OutgoingTransitionGroup=] and each `outgoingTransitionRefs` entry to an [=OutgoingTransition=].
+2. **Iteration:** The Consumer **MUST** iterate over every [=State=] and [=CompositeState=] ID in `stateRefs` except states referenced by a [=JourneyExit=] `exitStateRef` in the same journey.
 3. **Injection:** The Consumer **MUST** treat each iterated state as having an outgoing edge to every resolved [=OutgoingTransition=] `to`.
-4. **Deduplication:** A Consumer **SHOULD** treat injected and explicit edges with the same effective `from` and `to` as one effective edge.
+4. **Boundary states:** The Consumer **MUST NOT** create effective outgoing transitions from a state referenced by [=JourneyExit=] `exitStateRef` in the same journey.
+5. **Deduplication:** A Consumer **SHOULD** treat injected and explicit edges with the same effective `from` and `to` as one effective edge.
 </spec-statement>
 
 ---
 
 ## Ontology {data-cop-concept="ontology"}
 
-The normative Graph ontology is defined below and is published at `https://ujg.specs.openuji.org/ed/ns/graph`. It is the authoritative structural definition for Graph classes and properties, including `Journey`, `State`, `CompositeState`, `Transition`, `OutgoingTransition`, and `OutgoingTransitionGroup`.
+The normative Graph ontology is defined below and is published at `https://ujg.specs.openuji.org/ed/ns/graph`. It is the authoritative structural definition for Graph classes and properties, including `Journey`, `State`, `CompositeState`, `Transition`, `JourneyExit`, `OutgoingTransition`, `OutgoingTransitionGroup`, `exitRefs`, `exitRef`, and `exitStateRef`.
 
 :::include ./graph.ttl :::
 
@@ -119,6 +210,7 @@ The normative Graph JSON-LD context is defined below and is published at `https:
 :::include ./graph.context.jsonld :::
 
 ---
+
 ## Validation {data-cop-concept="validation"}
 
 The normative Graph SHACL shape is defined below and is published at `https://ujg.specs.openuji.org/ed/ns/graph.shape`. It is the authoritative validation artifact for Graph structural constraints.
@@ -129,14 +221,102 @@ The rules below define additional graph integrity and resolution behavior beyond
 
 <spec-statement>
 To ensure graph integrity, the following constraints **MUST** be met:
-1. **Reference Integrity:** All `startState`, `stateRefs`, `transitionRefs`, `outgoingTransitionGroupRefs`, and `outgoingTransitionRefs` IDs **MUST** resolve to valid Nodes within the current scope or imported modules.
+1. **Reference Integrity:** All `startState`, `stateRefs`, `transitionRefs`, `exitRefs`, `outgoingTransitionGroupRefs`, and `outgoingTransitionRefs` IDs **MUST** resolve to valid Nodes within the current scope or imported modules.
 2. **Transition Endpoint Resolution:** The `from` and `to` IDs of a [=Transition=] **MUST** resolve to valid Nodes, and are required to be members of the enclosing [=Journey=]'s `stateRefs`. A transition **MUST NOT** reference states belonging to other journeys.
-3. **Composition Safety**: `subjourneyId` **MUST** resolve to a valid [=Journey=].
-4. **Group Resolution**: Every ID in `outgoingTransitionGroupRefs` **MUST** resolve to an [=OutgoingTransitionGroup=].
-5. **Outgoing Resolution**: Every ID in `outgoingTransitionRefs` **MUST** resolve to an [=OutgoingTransition=].
+3. **Composition Safety:** `subjourneyId` **MUST** resolve to a valid [=Journey=].
+4. **Journey Exit Resolution:** Every ID in `exitRefs` **MUST** resolve to a [=JourneyExit=].
+5. **Group Resolution:** Every ID in `outgoingTransitionGroupRefs` **MUST** resolve to an [=OutgoingTransitionGroup=].
+6. **Outgoing Resolution:** Every ID in `outgoingTransitionRefs` **MUST** resolve to an [=OutgoingTransition=].
 </spec-statement>
 
 ---
+
+## Non-Goals {data-cop-concept="non-goals"}
+
+This module does **not** introduce cross-journey `from` or `to` endpoints.
+
+This module does **not** allow parent transitions to directly reference states that are not listed in the parent journey's `stateRefs`.
+
+This module does **not** replace `CompositeState.subjourneyId`.
+
+This module does **not** model runtime facts such as submitted form data, typed query text, selected result, clicked button, observed user behavior, analytics events, or runtime conditions.
+
+This module does **not** introduce guards, conditions, priorities, fallback matching, or runtime event matching.
+
+---
+
+## Appendix: Exported Exit JSON Example {.unnumbered}
+
+This example shows a parent journey with a `CompositeState`, a child journey, a child `JourneyExit`, and a parent transition that uses `exitRef`. The parent transition's `from` value is the parent-local `CompositeState`, its `to` value is a parent-local `State`, and its `exitRef` identifies the exported child journey exit. The parent transition does not reference the child state directly.
+
+```json
+{
+  "@context": "https://ujg.specs.openuji.org/ed/ns/context.jsonld",
+  "@id": "https://example.com/ujg/graph/w3c-search.jsonld",
+  "@type": "UJGDocument",
+  "nodes": [
+    {
+      "@type": "Journey",
+      "@id": "urn:ujg:journey:w3c-search",
+      "label": "W3C search journey",
+      "startState": "urn:ujg:state:w3c-search-searchpage",
+      "stateRefs": ["urn:ujg:state:w3c-search-searchpage", "urn:ujg:state:w3c-search-results"],
+      "transitionRefs": ["urn:ujg:transition:w3c-search-searchpage-to-results"]
+    },
+    {
+      "@type": "CompositeState",
+      "@id": "urn:ujg:state:w3c-search-searchpage",
+      "label": "SearchPage",
+      "subjourneyId": "urn:ujg:journey:w3c-searchpage"
+    },
+    {
+      "@type": "State",
+      "@id": "urn:ujg:state:w3c-search-results",
+      "label": "Results"
+    },
+    {
+      "@type": "Transition",
+      "@id": "urn:ujg:transition:w3c-search-searchpage-to-results",
+      "label": "Search results",
+      "from": "urn:ujg:state:w3c-search-searchpage",
+      "to": "urn:ujg:state:w3c-search-results",
+      "exitRef": "urn:ujg:exit:w3c-searchpage-submitted"
+    },
+    {
+      "@type": "Journey",
+      "@id": "urn:ujg:journey:w3c-searchpage",
+      "label": "W3C search page journey",
+      "startState": "urn:ujg:state:w3c-searchpage-form",
+      "stateRefs": ["urn:ujg:state:w3c-searchpage-form", "urn:ujg:state:w3c-searchpage-submitted"],
+      "transitionRefs": ["urn:ujg:transition:w3c-searchpage-form-to-submitted"],
+      "exitRefs": ["urn:ujg:exit:w3c-searchpage-submitted"]
+    },
+    {
+      "@type": "State",
+      "@id": "urn:ujg:state:w3c-searchpage-form",
+      "label": "Search form"
+    },
+    {
+      "@type": "State",
+      "@id": "urn:ujg:state:w3c-searchpage-submitted",
+      "label": "Submitted"
+    },
+    {
+      "@type": "JourneyExit",
+      "@id": "urn:ujg:exit:w3c-searchpage-submitted",
+      "label": "Submitted",
+      "exitStateRef": "urn:ujg:state:w3c-searchpage-submitted"
+    },
+    {
+      "@type": "Transition",
+      "@id": "urn:ujg:transition:w3c-searchpage-form-to-submitted",
+      "label": "Submit search form",
+      "from": "urn:ujg:state:w3c-searchpage-form",
+      "to": "urn:ujg:state:w3c-searchpage-submitted"
+    }
+  ]
+}
+```
 
 ## Appendix: Combined JSON Example {.unnumbered}
 


### PR DESCRIPTION
## Summary

Adds first-class `JourneyExit` support to the Graph Editor’s Draft so nested child journeys can export named boundary exits and parent journeys can map those exits to parent-local transitions from a `CompositeState`.

## Changes

- Adds `JourneyExit`, `exitRefs`, `exitRef`, and `exitStateRef` to the Graph ontology and JSON-LD context.
- Adds SHACL validation for journey exits, exit-state locality, parent transition `exitRef` mappings, duplicate exit mappings, and preservation of local `from`/`to` endpoint constraints.
- Refactors the Graph spec prose with:
  - exported journey exit terminology
  - boundary state requirements
  - strict exported-exit processing model
  - authoring guidance and non-goals
  - a complete JSON-LD example showing parent-local transition endpoints
