### PR TITLE
provide boundary state

### DIFF
--- a/apps/web/src/components/astro/speculator/BlockRenderer.astro
+++ b/apps/web/src/components/astro/speculator/BlockRenderer.astro
@@ -87,17 +87,16 @@ const getSectionNumber = (sectionId?: string): string | undefined => {
         if (node.lang === 'mermaid') {
           return <Mermaid code={node.value} id={node.id} />;
         }
-        const collapsible =
-          (currentSectionConcept === 'ontology' && node.lang === 'turtle') ||
-          (currentSectionConcept === 'jsonld-context' && node.lang === 'json-ld') ||
-          (currentSectionConcept === 'validation' && node.lang === 'turtle');
+
+        const lineCount = node.value.split(/\r\n|\r|\n/).length;
+
         // Regular code block
         const codeBlock = (
           <CodeCustom
             id={node.id || undefined}
             code={node.value}
             lang={node.lang as CodeLanguage}
-            collapsible={collapsible}
+            collapsible={lineCount > 10}
           />
         );
         return codeBlock;

--- a/apps/web/src/components/astro/speculator/Mermaid.astro
+++ b/apps/web/src/components/astro/speculator/Mermaid.astro
@@ -46,6 +46,9 @@ const { code, id } = Astro.props;
           tertiaryTextColor: '#f3f4f8',
           mainBkg: '#1a2340',
           nodeBkg: '#1a2340',
+          noteBkgColor: '#2f2712',
+          noteTextColor: '#f8e7a1',
+          noteBorderColor: '#c99a2e',
           edgeLabelBackground: '#27272a',
           clusterBkg: '#10182e',
           clusterBorder: '#33416b',
@@ -180,5 +183,29 @@ const { code, id } = Astro.props;
   .mermaid-container :global(.cluster-label span p) {
     font-size: 0.82rem !important;
     padding: 0.2rem 0.4rem !important;
+  }
+
+  :global(:root[data-theme='dark']) .mermaid-container :global(.note) {
+    fill: #2f2712 !important;
+    stroke: #c99a2e !important;
+  }
+
+  :global(:root[data-theme='dark']) .mermaid-container :global(.noteText),
+  :global(:root[data-theme='dark']) .mermaid-container :global(.noteText tspan) {
+    fill: #f8e7a1 !important;
+    color: #f8e7a1 !important;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :global(:root:not([data-theme='light'])) .mermaid-container :global(.note) {
+      fill: #2f2712 !important;
+      stroke: #c99a2e !important;
+    }
+
+    :global(:root:not([data-theme='light'])) .mermaid-container :global(.noteText),
+    :global(:root:not([data-theme='light'])) .mermaid-container :global(.noteText tspan) {
+      fill: #f8e7a1 !important;
+      color: #f8e7a1 !important;
+    }
   }
 </style>

--- a/specs/ed/graph/content-manifest.json
+++ b/specs/ed/graph/content-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
   "publishedAt": "2026-02-14T16:41:32.000Z",
-  "updatedAt": "2026-06-11T17:16:08.051Z",
-  "contentHash": "sha256:7ccbefd471e82212ed8d45343457d65398f521ebc86d55396143ae8981718777"
+  "updatedAt": "2026-06-12T09:47:11.171Z",
+  "contentHash": "sha256:3860c6f1d2044eccad1e6f259cdaa38e1e0f0b01232a08d7d0ab4f52404ebd2a"
 }

--- a/specs/ed/graph/content-manifest.json
+++ b/specs/ed/graph/content-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
   "publishedAt": "2026-02-14T16:41:32.000Z",
-  "updatedAt": "2026-06-12T09:47:11.171Z",
-  "contentHash": "sha256:3860c6f1d2044eccad1e6f259cdaa38e1e0f0b01232a08d7d0ab4f52404ebd2a"
+  "updatedAt": "2026-06-12T10:09:33.266Z",
+  "contentHash": "sha256:65aa4df97b5ffbc90565bad64af1df4a12c6d63bc990a16042b9681970016b4f"
 }

--- a/specs/ed/graph/content-manifest.json
+++ b/specs/ed/graph/content-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
   "publishedAt": "2026-02-14T16:41:32.000Z",
-  "updatedAt": "2026-06-12T10:09:33.266Z",
-  "contentHash": "sha256:65aa4df97b5ffbc90565bad64af1df4a12c6d63bc990a16042b9681970016b4f"
+  "updatedAt": "2026-06-12T10:37:57.341Z",
+  "contentHash": "sha256:b124d5b57a833bf733d8473b36274e56ba59296948b93e21c79b1a223324a0c0"
 }

--- a/specs/ed/graph/content-manifest.json
+++ b/specs/ed/graph/content-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
   "publishedAt": "2026-02-14T16:41:32.000Z",
-  "updatedAt": "2026-06-10T15:16:42.222Z",
-  "contentHash": "sha256:767e6b5e623bfa662b6b436dac216d33bd10cc0374fa2b847a122fcd2db81666"
+  "updatedAt": "2026-06-11T17:16:08.051Z",
+  "contentHash": "sha256:7ccbefd471e82212ed8d45343457d65398f521ebc86d55396143ae8981718777"
 }

--- a/specs/ed/graph/graph.context.jsonld
+++ b/specs/ed/graph/graph.context.jsonld
@@ -7,6 +7,7 @@
     "Journey": "ujggraph:Journey",
     "State": "ujggraph:State",
     "CompositeState": "ujggraph:CompositeState",
+    "BoundaryState": "ujggraph:BoundaryState",
     "Transition": "ujggraph:Transition",
     "JourneyExit": "ujggraph:JourneyExit",
     "OutgoingTransition": "ujggraph:OutgoingTransition",

--- a/specs/ed/graph/graph.context.jsonld
+++ b/specs/ed/graph/graph.context.jsonld
@@ -18,8 +18,8 @@
       "@id": "ujggraph:tags",
       "@container": "@set"
     },
-    "startState": {
-      "@id": "ujggraph:startState",
+    "startStateRef": {
+      "@id": "ujggraph:startStateRef",
       "@type": "@id"
     },
     "stateRefs": {
@@ -50,8 +50,8 @@
       "@id": "ujggraph:to",
       "@type": "@id"
     },
-    "exitRef": {
-      "@id": "ujggraph:exitRef",
+    "fromExitRef": {
+      "@id": "ujggraph:fromExitRef",
       "@type": "@id"
     },
     "subjourneyId": {

--- a/specs/ed/graph/graph.shape.ttl
+++ b/specs/ed/graph/graph.shape.ttl
@@ -12,12 +12,29 @@ ujggraphshape:StateLikeShape a sh:NodeShape ;
     [ sh:class ujggraph:BoundaryState ]
   ) .
 
+ujggraphshape:OutgoingTargetShape a sh:NodeShape ;
+  sh:nodeKind sh:IRI ;
+  sh:or (
+    [ sh:class ujggraph:State ]
+    [ sh:class ujggraph:CompositeState ]
+  ) ;
+  sh:sparql [
+    a sh:SPARQLConstraint ;
+    sh:message "OutgoingTransition.to must not reference a BoundaryState." ;
+    sh:select """
+      SELECT $this
+      WHERE {
+        $this a ujggraph:BoundaryState .
+      }
+    """ ;
+  ] .
+
 ujggraphshape:JourneyShape a sh:NodeShape ;
   sh:targetClass ujggraph:Journey ;
   sh:nodeKind sh:IRI ;
 
   sh:property [
-    sh:path ujggraph:startState ;
+    sh:path ujggraph:startStateRef ;
     sh:minCount 1 ;
     sh:maxCount 1 ;
     sh:node ujggraphshape:StateLikeShape ;
@@ -153,12 +170,12 @@ ujggraphshape:JourneyShape a sh:NodeShape ;
 
   sh:sparql [
     a sh:SPARQLConstraint ;
-    sh:message "A transition with exitRef must have a from value listed in the enclosing journey's stateRefs." ;
+    sh:message "A transition with fromExitRef must have a from value listed in the enclosing journey's stateRefs." ;
     sh:select """
       SELECT $this ?transition ?from
       WHERE {
         $this ujggraph:transitionRefs ?transition .
-        ?transition ujggraph:exitRef ?exit ;
+        ?transition ujggraph:fromExitRef ?exit ;
                     ujggraph:from ?from .
 
         FILTER (NOT EXISTS {
@@ -170,12 +187,12 @@ ujggraphshape:JourneyShape a sh:NodeShape ;
 
   sh:sparql [
     a sh:SPARQLConstraint ;
-    sh:message "A transition with exitRef must have a from value that references a CompositeState." ;
+    sh:message "A transition with fromExitRef must have a from value that references a CompositeState." ;
     sh:select """
       SELECT $this ?transition ?from
       WHERE {
         $this ujggraph:transitionRefs ?transition .
-        ?transition ujggraph:exitRef ?exit ;
+        ?transition ujggraph:fromExitRef ?exit ;
                     ujggraph:from ?from .
 
         FILTER (NOT EXISTS {
@@ -187,12 +204,12 @@ ujggraphshape:JourneyShape a sh:NodeShape ;
 
   sh:sparql [
     a sh:SPARQLConstraint ;
-    sh:message "The CompositeState used as from by a transition with exitRef must declare exactly one subjourneyId." ;
+    sh:message "The CompositeState used as from by a transition with fromExitRef must declare exactly one subjourneyId." ;
     sh:select """
       SELECT $this ?transition ?from
       WHERE {
         $this ujggraph:transitionRefs ?transition .
-        ?transition ujggraph:exitRef ?exit ;
+        ?transition ujggraph:fromExitRef ?exit ;
                     ujggraph:from ?from .
 
         FILTER (
@@ -208,12 +225,12 @@ ujggraphshape:JourneyShape a sh:NodeShape ;
 
   sh:sparql [
     a sh:SPARQLConstraint ;
-    sh:message "The subjourneyId of the CompositeState used by a transition with exitRef must resolve to a Journey." ;
+    sh:message "The subjourneyId of the CompositeState used by a transition with fromExitRef must resolve to a Journey." ;
     sh:select """
       SELECT $this ?transition ?from ?subjourney
       WHERE {
         $this ujggraph:transitionRefs ?transition .
-        ?transition ujggraph:exitRef ?exit ;
+        ?transition ujggraph:fromExitRef ?exit ;
                     ujggraph:from ?from .
         ?from ujggraph:subjourneyId ?subjourney .
 
@@ -226,12 +243,12 @@ ujggraphshape:JourneyShape a sh:NodeShape ;
 
   sh:sparql [
     a sh:SPARQLConstraint ;
-    sh:message "The exitRef of a parent transition must be listed in the exitRefs of the child journey referenced by the from CompositeState." ;
+    sh:message "The fromExitRef of a parent transition must be listed in the exitRefs of the child journey referenced by the from CompositeState." ;
     sh:select """
       SELECT $this ?transition ?from ?subjourney ?exit
       WHERE {
         $this ujggraph:transitionRefs ?transition .
-        ?transition ujggraph:exitRef ?exit ;
+        ?transition ujggraph:fromExitRef ?exit ;
                     ujggraph:from ?from .
         ?from ujggraph:subjourneyId ?subjourney .
 
@@ -244,12 +261,12 @@ ujggraphshape:JourneyShape a sh:NodeShape ;
 
   sh:sparql [
     a sh:SPARQLConstraint ;
-    sh:message "A transition with exitRef must have a to value listed in the enclosing journey's stateRefs." ;
+    sh:message "A transition with fromExitRef must have a to value listed in the enclosing journey's stateRefs." ;
     sh:select """
       SELECT $this ?transition ?to
       WHERE {
         $this ujggraph:transitionRefs ?transition .
-        ?transition ujggraph:exitRef ?exit ;
+        ?transition ujggraph:fromExitRef ?exit ;
                     ujggraph:to ?to .
 
         FILTER (NOT EXISTS {
@@ -261,15 +278,15 @@ ujggraphshape:JourneyShape a sh:NodeShape ;
 
   sh:sparql [
     a sh:SPARQLConstraint ;
-    sh:message "A journey must not contain more than one transition with the same from value and the same exitRef value." ;
+    sh:message "A journey must not contain more than one transition with the same from value and the same fromExitRef value." ;
     sh:select """
       SELECT $this ?from ?exit ?transition ?otherTransition
       WHERE {
         $this ujggraph:transitionRefs ?transition, ?otherTransition .
         ?transition ujggraph:from ?from ;
-                    ujggraph:exitRef ?exit .
+                    ujggraph:fromExitRef ?exit .
         ?otherTransition ujggraph:from ?from ;
-                         ujggraph:exitRef ?exit .
+                         ujggraph:fromExitRef ?exit .
         FILTER (?transition != ?otherTransition)
       }
     """ ;
@@ -397,7 +414,7 @@ ujggraphshape:TransitionShape a sh:NodeShape ;
   ] ;
 
   sh:property [
-    sh:path ujggraph:exitRef ;
+    sh:path ujggraph:fromExitRef ;
     sh:class ujggraph:JourneyExit ;
     sh:nodeKind sh:IRI ;
     sh:maxCount 1 ;
@@ -429,7 +446,7 @@ ujggraphshape:OutgoingTransitionShape a sh:NodeShape ;
     sh:path ujggraph:to ;
     sh:minCount 1 ;
     sh:maxCount 1 ;
-    sh:node ujggraphshape:StateLikeShape ;
+    sh:node ujggraphshape:OutgoingTargetShape ;
   ] ;
 
   sh:property [

--- a/specs/ed/graph/graph.shape.ttl
+++ b/specs/ed/graph/graph.shape.ttl
@@ -48,7 +48,6 @@ ujggraphshape:JourneyShape a sh:NodeShape ;
 
   sh:property [
     sh:path ujggraph:transitionRefs ;
-    sh:minCount 1 ;
     sh:class ujggraph:Transition ;
     sh:nodeKind sh:IRI ;
   ] ;

--- a/specs/ed/graph/graph.shape.ttl
+++ b/specs/ed/graph/graph.shape.ttl
@@ -9,6 +9,7 @@ ujggraphshape:StateLikeShape a sh:NodeShape ;
   sh:or (
     [ sh:class ujggraph:State ]
     [ sh:class ujggraph:CompositeState ]
+    [ sh:class ujggraph:BoundaryState ]
   ) .
 
 ujggraphshape:JourneyShape a sh:NodeShape ;
@@ -132,6 +133,20 @@ ujggraphshape:JourneyShape a sh:NodeShape ;
               ujggraph:transitionRefs ?transition .
         ?exit ujggraph:exitStateRef ?exitState .
         ?transition ujggraph:from ?exitState .
+      }
+    """ ;
+  ] ;
+
+  sh:sparql [
+    a sh:SPARQLConstraint ;
+    sh:message "A BoundaryState listed in a journey's stateRefs must not be used as the from value of a transition listed in the same journey." ;
+    sh:select """
+      SELECT $this ?boundaryState ?transition
+      WHERE {
+        $this ujggraph:stateRefs ?boundaryState ;
+              ujggraph:transitionRefs ?transition .
+        ?boundaryState a ujggraph:BoundaryState .
+        ?transition ujggraph:from ?boundaryState .
       }
     """ ;
   ] ;
@@ -274,6 +289,51 @@ ujggraphshape:StateShape a sh:NodeShape ;
   sh:property [
     sh:path ujggraph:tags ;
     sh:datatype xsd:string ;
+  ] ;
+
+  sh:property [
+    sh:path ujggraph:outgoingTransitionRefs ;
+    sh:class ujggraph:OutgoingTransition ;
+    sh:nodeKind sh:IRI ;
+  ] .
+
+ujggraphshape:BoundaryStateShape a sh:NodeShape ;
+  sh:targetClass ujggraph:BoundaryState ;
+  sh:nodeKind sh:IRI ;
+
+  sh:property [
+    sh:path ujggraph:label ;
+    sh:datatype xsd:string ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] ;
+
+  sh:property [
+    sh:path ujggraph:tags ;
+    sh:datatype xsd:string ;
+  ] ;
+
+  sh:property [
+    sh:path ujggraph:subjourneyId ;
+    sh:maxCount 0 ;
+    sh:message "A BoundaryState must not declare subjourneyId." ;
+  ] ;
+
+  sh:property [
+    sh:path ujggraph:outgoingTransitionRefs ;
+    sh:maxCount 0 ;
+    sh:message "A BoundaryState must not declare outgoingTransitionRefs." ;
+  ] ;
+
+  sh:sparql [
+    a sh:SPARQLConstraint ;
+    sh:message "A BoundaryState must not also be typed CompositeState." ;
+    sh:select """
+      SELECT $this
+      WHERE {
+        $this a ujggraph:CompositeState .
+      }
+    """ ;
   ] .
 
 ujggraphshape:CompositeStateShape a sh:NodeShape ;
@@ -296,6 +356,12 @@ ujggraphshape:CompositeStateShape a sh:NodeShape ;
     sh:path ujggraph:stateRefs ;
     sh:maxCount 0 ;
     sh:message "A CompositeState must not use stateRefs; use subjourneyId to reference a Journey." ;
+  ] ;
+
+  sh:property [
+    sh:path ujggraph:outgoingTransitionRefs ;
+    sh:maxCount 0 ;
+    sh:message "A CompositeState must not declare outgoingTransitionRefs. Use an OutgoingTransitionGroup on the enclosing Journey, or attach outgoingTransitionRefs to concrete states inside the referenced subjourney." ;
   ] ;
 
   sh:property [
@@ -352,7 +418,7 @@ ujggraphshape:JourneyExitShape a sh:NodeShape ;
     sh:minCount 1 ;
     sh:maxCount 1 ;
     sh:nodeKind sh:IRI ;
-    sh:node ujggraphshape:StateLikeShape ;
+    sh:class ujggraph:BoundaryState ;
   ] .
 
 ujggraphshape:OutgoingTransitionShape a sh:NodeShape ;

--- a/specs/ed/graph/graph.ttl
+++ b/specs/ed/graph/graph.ttl
@@ -21,6 +21,12 @@ ujggraph:State a owl:Class ;
 ujggraph:CompositeState a owl:Class ;
   rdfs:subClassOf ujggraph:State .
 
+ujggraph:BoundaryState a owl:Class ;
+  rdfs:subClassOf ujggraph:State ;
+  owl:disjointWith ujggraph:CompositeState ;
+  rdfs:label "Boundary State" ;
+  rdfs:comment "A terminal state that represents an exported outcome of a journey and may be referenced by JourneyExit.exitStateRef." .
+
 ujggraph:Transition a owl:Class ;
   rdfs:subClassOf ujg:Node .
 
@@ -85,10 +91,18 @@ ujggraph:subjourneyId a owl:ObjectProperty ;
 
 ujggraph:exitStateRef a owl:ObjectProperty ;
   rdfs:domain ujggraph:JourneyExit ;
-  rdfs:range ujggraph:State ;
+  rdfs:range ujggraph:BoundaryState ;
   rdfs:label "exit state ref" ;
-  rdfs:comment "References the boundary state local to the journey that declares this JourneyExit." .
+  rdfs:comment "References the BoundaryState that represents the exported outcome of the declaring journey." .
 
 ujggraph:outgoingTransitionRefs a owl:ObjectProperty ;
-  rdfs:domain ujggraph:OutgoingTransitionGroup ;
-  rdfs:range ujggraph:OutgoingTransition .
+  rdfs:domain [
+    a owl:Class ;
+    owl:unionOf (
+      ujggraph:State
+      ujggraph:OutgoingTransitionGroup
+    )
+  ] ;
+  rdfs:range ujggraph:OutgoingTransition ;
+  rdfs:label "outgoing transition refs" ;
+  rdfs:comment "References outgoing navigational affordances. When used on an OutgoingTransitionGroup, the references define a reusable group. When used on a non-composite State, the references define outgoing affordances available from that specific state." .

--- a/specs/ed/graph/graph.ttl
+++ b/specs/ed/graph/graph.ttl
@@ -51,9 +51,11 @@ ujggraph:tags a owl:DatatypeProperty ;
   rdfs:domain ujg:Node ;
   rdfs:range xsd:string .
 
-ujggraph:startState a owl:ObjectProperty ;
+ujggraph:startStateRef a owl:ObjectProperty ;
   rdfs:domain ujggraph:Journey ;
-  rdfs:range ujggraph:State .
+  rdfs:range ujggraph:State ;
+  rdfs:label "start state ref" ;
+  rdfs:comment "References the start state of a journey." .
 
 ujggraph:stateRefs a owl:ObjectProperty ;
   rdfs:range ujggraph:State .
@@ -79,11 +81,11 @@ ujggraph:from a owl:ObjectProperty ;
 ujggraph:to a owl:ObjectProperty ;
   rdfs:range ujggraph:State .
 
-ujggraph:exitRef a owl:ObjectProperty ;
+ujggraph:fromExitRef a owl:ObjectProperty ;
   rdfs:domain ujggraph:Transition ;
   rdfs:range ujggraph:JourneyExit ;
-  rdfs:label "exit ref" ;
-  rdfs:comment "Identifies the exported JourneyExit reached by the child journey of a CompositeState used as the transition's from value. This property is not a transition endpoint." .
+  rdfs:label "from exit ref" ;
+  rdfs:comment "Identifies the exported JourneyExit completed by the child journey of the CompositeState used as the transition's from value. This property is not a transition endpoint." .
 
 ujggraph:subjourneyId a owl:ObjectProperty ;
   rdfs:domain ujggraph:CompositeState ;

--- a/specs/ed/graph/index.md
+++ b/specs/ed/graph/index.md
@@ -18,9 +18,9 @@ Examples in this page use an explicit context array composed from the published 
 - <dfn>State</dfn>: A discrete node in the experience (e.g., a screen, modal).
 - <dfn>Transition</dfn>: A directed edge between two states.
 - <dfn>CompositeState</dfn>: A state that encapsulates another [=Journey=] (sub-journey).
+- <dfn>BoundaryState</dfn>: A terminal [=State=] that represents an exported outcome of a [=Journey=].
 - <dfn>JourneyExit</dfn>: An exported boundary contract declared by a [=Journey=].
-- <dfn>Boundary state</dfn>: A [=State=] or [=CompositeState=] listed in a [=Journey=]'s `stateRefs` that represents a completed outcome of that journey.
-- <dfn>OutgoingTransition</dfn>: A one way edge pointing to a next possible [=State=].
+- <dfn>OutgoingTransition</dfn>: A navigational affordance pointing to a next possible [=State=], [=CompositeState=], or [=BoundaryState=].
 - <dfn>OutgoingTransitionGroup</dfn>: A reusable set of outgoing transitions that a Consumer can treat as present on multiple states (e.g., global nav).
 
 ---
@@ -62,7 +62,7 @@ The structural definition of [=CompositeState=] and `subjourneyId` is normative 
 
 A [=JourneyExit=] lets a child [=Journey=] export one or more named boundary exits. A parent [=Journey=] can then map each exported exit to a parent-local [=Transition=] from the [=CompositeState=] that references the child journey.
 
-A [=JourneyExit=] identifies one local [=Boundary state=] of the declaring journey using `exitStateRef`. It allows an enclosing parent journey to distinguish which exported outcome of a nested child journey was reached without allowing the parent journey to reference child states directly.
+A [=JourneyExit=] identifies one local [=BoundaryState=] of the declaring journey using `exitStateRef`. It allows an enclosing parent journey to distinguish which exported outcome of a nested child journey was reached without allowing the parent journey to reference child states directly.
 
 `exitRef` is a mapping property on a parent transition. It is not a transition endpoint. A transition's `from` and `to` values remain local to the enclosing journey.
 
@@ -87,7 +87,7 @@ graph LR
 1. A [=Journey=] **MAY** declare `exitRefs`.
 2. Each value of `exitRefs` **MUST** reference a [=JourneyExit=].
 3. A [=JourneyExit=] **MUST** declare exactly one `exitStateRef`.
-4. The `exitStateRef` of a [=JourneyExit=] declared by a journey **MUST** reference a [=State=] or [=CompositeState=] listed in that same journey's `stateRefs`.
+4. The `exitStateRef` of a [=JourneyExit=] declared by a journey **MUST** reference a [=BoundaryState=] listed in that same journey's `stateRefs`.
 5. A [=JourneyExit=] **MUST** be declared by no more than one [=Journey=].
 6. A [=Journey=] **MUST NOT** list more than one [=JourneyExit=] with the same `exitStateRef`.
 </spec-statement>
@@ -100,28 +100,34 @@ graph LR
 5. The `subjourneyId` value **MUST** resolve to a [=Journey=].
 6. The `exitRef` value **MUST** be listed in the `exitRefs` of the journey referenced by the `from` composite state's `subjourneyId`.
 7. `exitRef` **MUST NOT** weaken, replace, or bypass local transition endpoint validation.
-8. A transition's `from` and `to` values **MUST** continue to reference states or composite states listed in the enclosing journey's `stateRefs`.
+8. A transition's `from` and `to` values **MUST** continue to reference states, composite states, or boundary states listed in the enclosing journey's `stateRefs`.
 9. A parent transition **MUST NOT** directly reference a child journey's state as `from`, `to`, or through any child-state-specific transition property.
 10. A journey **MUST NOT** contain more than one transition with the same `from` value and the same `exitRef` value.
 </spec-statement>
 
-### Boundary States
+### BoundaryState
 
 <spec-statement>
-1. A state referenced by `JourneyExit.exitStateRef` **MUST** be a [=Boundary state=] for the declaring journey.
-2. A state referenced by `JourneyExit.exitStateRef` **MUST NOT** be used as the `from` value of another [=Transition=] listed in the same journey's `transitionRefs`.
-3. Outgoing transition group injection **MUST NOT** create effective outgoing transitions from a state referenced by `JourneyExit.exitStateRef` in the same journey.
-4. A [=JourneyExit=] **MUST NOT** be used for ordinary internal child transitions. Internal movement inside the child journey **MUST** continue to use normal [=Transition=] resources.
-5. Runtime observations, user actions, form values, clicked elements, submitted values, selected values, analytics facts, or other runtime facts **MUST NOT** be modeled in the Graph module through [=JourneyExit=]. Runtime facts remain outside the Graph module.
-6. If `exitStateRef` references a [=CompositeState=], the declaring journey reaches that [=JourneyExit=] only when interpretation of that composite state has completed according to the exported-exit processing model.
+1. A [=BoundaryState=] represents an exported terminal outcome of a [=Journey=].
+2. A [=BoundaryState=] **MUST NOT** also be a [=CompositeState=].
+3. A [=BoundaryState=] **MUST NOT** declare `subjourneyId`.
+4. A [=BoundaryState=] **MUST NOT** declare `outgoingTransitionRefs`.
+5. A [=BoundaryState=] listed in a [=Journey=]'s `stateRefs` **MUST NOT** be used as the `from` value of another [=Transition=] listed in that same journey's `transitionRefs`.
+6. Outgoing transition group injection **MUST NOT** create effective outgoing transitions from a [=BoundaryState=].
+7. A [=JourneyExit=] `exitStateRef` **MUST** reference a [=BoundaryState=].
+8. A [=JourneyExit=] `exitStateRef` **MUST NOT** reference a [=CompositeState=].
+9. A [=JourneyExit=] **MUST NOT** be used for ordinary internal child transitions. Internal movement inside the child journey **MUST** continue to use normal [=Transition=] resources.
+10. Runtime observations, user actions, form values, clicked elements, submitted values, selected values, analytics facts, or other runtime facts **MUST NOT** be modeled in the Graph module through [=JourneyExit=]. Runtime facts remain outside the Graph module.
 </spec-statement>
+
+If a [=CompositeState=] completes and needs to export an outcome upward, the declaring journey SHOULD transition to a local [=BoundaryState=], and the [=JourneyExit=] SHOULD reference that [=BoundaryState=].
 
 ### Processing Model
 
 <spec-statement>
 When a Consumer enters a [=CompositeState=], it **MAY** resolve the composite state's `subjourneyId` and interpret the referenced child [=Journey=].
 
-If interpretation of the child journey reaches a state that is the `exitStateRef` of a [=JourneyExit=] listed in that child journey's `exitRefs`, that [=JourneyExit=] becomes the exported exit of the child journey.
+If interpretation of the child journey reaches a [=BoundaryState=] that is the `exitStateRef` of a [=JourneyExit=] listed in that child journey's `exitRefs`, that [=JourneyExit=] becomes the exported exit of the child journey.
 
 If more than one [=JourneyExit=] listed by the same child journey has the same `exitStateRef`, the graph is invalid. A Consumer **MUST NOT** choose one arbitrarily.
 
@@ -151,6 +157,8 @@ Use [=JourneyExit=] when a nested journey has multiple explicit boundary outcome
 
 Do not use [=JourneyExit=] for ordinary transitions inside the child journey. Use normal child [=Transition=] resources for internal child movement.
 
+When a nested journey reaches a completed outcome, model that outcome with a local [=BoundaryState=] and reference it from the appropriate [=JourneyExit=].
+
 Do not use [=JourneyExit=] when the parent transition intentionally treats the composite state as an undifferentiated whole. In that case, a normal transition from the [=CompositeState=] without `exitRef` remains sufficient, and the child journey should not require exported exits for that parent-level behavior.
 
 ---
@@ -160,6 +168,22 @@ Do not use [=JourneyExit=] when the parent transition intentionally treats the c
 An [=OutgoingTransitionGroup=] defines reusable outgoing transitions (e.g., headers/footers) to avoid duplicating common navigation across many states.
 
 The structural definition of [=OutgoingTransitionGroup=] and [=OutgoingTransition=] is normative in the ontology and validation artifacts. This section defines only the consumer processing model for applying those reusable outgoing edges.
+
+### State-scoped Outgoing Transitions
+
+<spec-statement>
+1. A [=State=] **MAY** declare `outgoingTransitionRefs`.
+2. A [=CompositeState=] **MUST NOT** declare `outgoingTransitionRefs`.
+3. A [=BoundaryState=] **MUST NOT** declare `outgoingTransitionRefs`.
+4. Each `outgoingTransitionRefs` value **MUST** reference an [=OutgoingTransition=].
+5. A state-scoped [=OutgoingTransition=] represents a navigational affordance available from the declaring [=State=] only. It does not declare a structural transition in the enclosing [=Journey=].
+6. The effective source of a state-scoped [=OutgoingTransition=] is the [=State=] that declares the `outgoingTransitionRefs` value.
+7. `OutgoingTransition.to` **MAY** reference a resolvable [=State=], [=CompositeState=], or [=BoundaryState=] outside the [=Journey=] that contains the declaring [=State=].
+8. A Consumer **MUST NOT** treat a state-scoped [=OutgoingTransition=] as a member of the enclosing [=Journey=]'s `transitionRefs`.
+9. State-scoped `outgoingTransitionRefs` **MUST NOT** be used for ordinary internal journey progression when a local [=Transition=] is appropriate.
+</spec-statement>
+
+A [=CompositeState=] represents nested composition through `subjourneyId`. If navigation should be available while a composite state is active, model it either as an [=OutgoingTransitionGroup=] referenced by the enclosing journey or as direct `outgoingTransitionRefs` on concrete states inside the composite state's subjourney.
 
 ### Visual Model
 
@@ -184,22 +208,57 @@ graph TD
     linkStyle 1,2,3,4 stroke-dasharray: 5 5, stroke:green, color:green;
 ```
 
-### Processing Model (Injection)
+### Processing Model
 
 <spec-statement>
-When a Consumer loads a [=Journey=] referencing `outgoingTransitionGroupRefs`:
-1. **Resolution:** The Consumer **MUST** resolve each referenced [=OutgoingTransitionGroup=] and each `outgoingTransitionRefs` entry to an [=OutgoingTransition=].
-2. **Iteration:** The Consumer **MUST** iterate over every [=State=] and [=CompositeState=] ID in `stateRefs` except states referenced by a [=JourneyExit=] `exitStateRef` in the same journey.
+When a Consumer computes effective outgoing affordances for a state in a [=Journey=], it **MUST** consider:
+
+1. [=OutgoingTransitionGroup=] resources referenced by the enclosing journey's `outgoingTransitionGroupRefs`; and
+2. `outgoingTransitionRefs` declared directly on the current [=State=].
+
+For journey-level group injection:
+
+1. **Resolution:** The Consumer **MUST** resolve each referenced [=OutgoingTransitionGroup=] and each group `outgoingTransitionRefs` entry to an [=OutgoingTransition=].
+2. **Iteration:** The Consumer **MUST** iterate over every [=State=] and [=CompositeState=] ID in `stateRefs` except [=BoundaryState=] instances.
 3. **Injection:** The Consumer **MUST** treat each iterated state as having an outgoing edge to every resolved [=OutgoingTransition=] `to`.
-4. **Boundary states:** The Consumer **MUST NOT** create effective outgoing transitions from a state referenced by [=JourneyExit=] `exitStateRef` in the same journey.
-5. **Deduplication:** A Consumer **SHOULD** treat injected and explicit edges with the same effective `from` and `to` as one effective edge.
+4. **Boundary states:** The Consumer **MUST NOT** create effective outgoing transitions from a [=BoundaryState=].
+
+For state-level outgoing affordances:
+
+1. The Consumer **MUST** resolve each `outgoingTransitionRefs` value declared by the current [=State=] to an [=OutgoingTransition=].
+2. State-level `outgoingTransitionRefs` apply only to the [=State=] that declares them. They are not injected into other states.
+3. A Consumer **SHOULD** treat duplicate effective outgoing edges with the same effective source state and same [=OutgoingTransition=] `to` target as one effective edge.
 </spec-statement>
+
+### Example: State-scoped Back to Home
+
+This example shows a search form state with a local "Back to home page" affordance. This is not a structural [=Transition=] from the SearchPage journey to the Root journey. It is a state-scoped navigational affordance. The `to` target must resolve to a known [=State=], [=CompositeState=], or [=BoundaryState=], but it does not need to be listed in the current journey's `stateRefs`.
+
+```json
+{
+  "@type": "State",
+  "@id": "urn:ujg:state:w3c-searchpage-form",
+  "label": "Search form",
+  "outgoingTransitionRefs": [
+    "urn:ujg:ot:w3c-searchpage-form-back-home"
+  ]
+}
+```
+
+```json
+{
+  "@type": "OutgoingTransition",
+  "@id": "urn:ujg:ot:w3c-searchpage-form-back-home",
+  "label": "Back to home page",
+  "to": "urn:ujg:state:w3c-root-homepage"
+}
+```
 
 ---
 
 ## Ontology {data-cop-concept="ontology"}
 
-The normative Graph ontology is defined below and is published at `https://ujg.specs.openuji.org/ed/ns/graph`. It is the authoritative structural definition for Graph classes and properties, including `Journey`, `State`, `CompositeState`, `Transition`, `JourneyExit`, `OutgoingTransition`, `OutgoingTransitionGroup`, `exitRefs`, `exitRef`, and `exitStateRef`.
+The normative Graph ontology is defined below and is published at `https://ujg.specs.openuji.org/ed/ns/graph`. It is the authoritative structural definition for Graph classes and properties, including `Journey`, `State`, `CompositeState`, `BoundaryState`, `Transition`, `JourneyExit`, `OutgoingTransition`, `OutgoingTransitionGroup`, `exitRefs`, `exitRef`, `exitStateRef`, and `outgoingTransitionRefs`.
 
 :::include ./graph.ttl :::
 
@@ -235,9 +294,19 @@ To ensure graph integrity, the following constraints **MUST** be met:
 
 This module does **not** introduce cross-journey `from` or `to` endpoints.
 
+This module does **not** remove `Journey.transitionRefs` or move structural transitions onto states.
+
 This module does **not** allow parent transitions to directly reference states that are not listed in the parent journey's `stateRefs`.
 
+This module does **not** allow `Transition.from` or `Transition.to` to point outside the enclosing journey's `stateRefs`.
+
 This module does **not** replace `CompositeState.subjourneyId`.
+
+This module does **not** allow [=CompositeState=] to declare direct `outgoingTransitionRefs`.
+
+This module does **not** allow [=CompositeState=] as `JourneyExit.exitStateRef`.
+
+This module does **not** use [=OutgoingTransition=] for ordinary internal journey progression.
 
 This module does **not** model runtime facts such as submitted form data, typed query text, selected result, clicked button, observed user behavior, analytics events, or runtime conditions.
 
@@ -271,6 +340,11 @@ This example shows a parent journey with a `CompositeState`, a child journey, a 
     },
     {
       "@type": "State",
+      "@id": "urn:ujg:state:w3c-root-homepage",
+      "label": "Root homepage"
+    },
+    {
+      "@type": "State",
       "@id": "urn:ujg:state:w3c-search-results",
       "label": "Results"
     },
@@ -294,10 +368,11 @@ This example shows a parent journey with a `CompositeState`, a child journey, a 
     {
       "@type": "State",
       "@id": "urn:ujg:state:w3c-searchpage-form",
-      "label": "Search form"
+      "label": "Search form",
+      "outgoingTransitionRefs": ["urn:ujg:ot:w3c-searchpage-form-back-home"]
     },
     {
-      "@type": "State",
+      "@type": "BoundaryState",
       "@id": "urn:ujg:state:w3c-searchpage-submitted",
       "label": "Submitted"
     },
@@ -306,6 +381,12 @@ This example shows a parent journey with a `CompositeState`, a child journey, a 
       "@id": "urn:ujg:exit:w3c-searchpage-submitted",
       "label": "Submitted",
       "exitStateRef": "urn:ujg:state:w3c-searchpage-submitted"
+    },
+    {
+      "@type": "OutgoingTransition",
+      "@id": "urn:ujg:ot:w3c-searchpage-form-back-home",
+      "label": "Back to home page",
+      "to": "urn:ujg:state:w3c-root-homepage"
     },
     {
       "@type": "Transition",

--- a/specs/ed/graph/index.md
+++ b/specs/ed/graph/index.md
@@ -46,6 +46,17 @@ classDiagram
   }
 ```
 
+Example JSON node:
+
+```json
+{
+  "@type": "State",
+  "@id": "urn:ujg:state:search-form",
+  "label": "Search form",
+  "tags": ["phase:search"]
+}
+```
+
 ---
 
 ## Transition {data-cop-concept="transition"}
@@ -80,6 +91,18 @@ classDiagram
 
   Transition --> State : from
   Transition --> State : to
+```
+
+Example JSON node:
+
+```json
+{
+  "@type": "Transition",
+  "@id": "urn:ujg:transition:search-form-to-results",
+  "label": "Submit search",
+  "from": "urn:ujg:state:search-form",
+  "to": "urn:ujg:state:results"
+}
 ```
 
 ---
@@ -126,6 +149,24 @@ classDiagram
   Transition --> State : to
 ```
 
+Example JSON node:
+
+```json
+{
+  "@type": "Journey",
+  "@id": "urn:ujg:journey:site-search",
+  "label": "Site search",
+  "startStateRef": "urn:ujg:state:search-form",
+  "stateRefs": [
+    "urn:ujg:state:search-form",
+    "urn:ujg:state:results"
+  ],
+  "transitionRefs": [
+    "urn:ujg:transition:search-form-to-results"
+  ]
+}
+```
+
 ---
 
 ## CompositeState {data-cop-concept="composition"}
@@ -157,6 +198,17 @@ classDiagram
   CompositeState --> Journey : subjourneyId
 ```
 
+Example JSON node:
+
+```json
+{
+  "@type": "CompositeState",
+  "@id": "urn:ujg:state:checkout-flow",
+  "label": "Checkout flow",
+  "subjourneyId": "urn:ujg:journey:checkout"
+}
+```
+
 ---
 
 ## BoundaryState {data-cop-concept="boundary-state"}
@@ -174,12 +226,12 @@ Boundary states remain local states of the journey that declares them.
 6. Outgoing transition group injection **MUST NOT** create effective outgoing transitions from a [=BoundaryState=].
 </spec-statement>
 
+Informative visualization:
+
 ```mermaid
 classDiagram
   class State
-  class BoundaryState {
-    terminalOutcome
-  }
+  class BoundaryState
   class Journey {
     stateRefs
   }
@@ -191,6 +243,17 @@ classDiagram
   State <|-- BoundaryState
   Journey --> BoundaryState : stateRefs
   Transition --> BoundaryState : to
+```
+
+Example JSON node:
+
+```json
+{
+  "@type": "BoundaryState",
+  "@id": "urn:ujg:state:checkout-complete",
+  "label": "Checkout complete",
+  "tags": ["outcome:success"]
+}
 ```
 
 ---
@@ -231,9 +294,58 @@ classDiagram
   JourneyExit --> BoundaryState : exitStateRef
 ```
 
----
+Example JSON graph:
 
-## Parent Continuation with fromExitRef {data-cop-concept="parent-continuation"}
+```json
+{
+  "@context": "https://ujg.specs.openuji.org/ed/ns/context.jsonld",
+  "@id": "https://example.com/ujg/checkout-exit.jsonld",
+  "@type": "UJGDocument",
+  "nodes": [
+    {
+      "@type": "Journey",
+      "@id": "urn:ujg:journey:checkout",
+      "label": "Checkout journey",
+      "startStateRef": "urn:ujg:state:checkout-form",
+      "stateRefs": [
+        "urn:ujg:state:checkout-form",
+        "urn:ujg:state:checkout-complete"
+      ],
+      "transitionRefs": [
+        "urn:ujg:transition:checkout-form-to-complete"
+      ],
+      "exitRefs": [
+        "urn:ujg:exit:checkout-complete"
+      ]
+    },
+    {
+      "@type": "State",
+      "@id": "urn:ujg:state:checkout-form",
+      "label": "Checkout form"
+    },
+    {
+      "@type": "BoundaryState",
+      "@id": "urn:ujg:state:checkout-complete",
+      "label": "Checkout complete"
+    },
+    {
+      "@type": "Transition",
+      "@id": "urn:ujg:transition:checkout-form-to-complete",
+      "label": "Submit checkout",
+      "from": "urn:ujg:state:checkout-form",
+      "to": "urn:ujg:state:checkout-complete"
+    },
+    {
+      "@type": "JourneyExit",
+      "@id": "urn:ujg:exit:checkout-complete",
+      "label": "Checkout complete",
+      "exitStateRef": "urn:ujg:state:checkout-complete"
+    }
+  ]
+}
+```
+
+### Parent Continuation with fromExitRef {data-cop-concept="parent-continuation"}
 
 `fromExitRef` is a mapping property on a parent [=Transition=]. It identifies which exported [=JourneyExit=] completed for the child journey of the transition's `from` [=CompositeState=].
 
@@ -295,6 +407,103 @@ classDiagram
   Transition --> JourneyExit : fromExitRef
 ```
 
+Example JSON graph:
+
+```json
+{
+  "@context": "https://ujg.specs.openuji.org/ed/ns/context.jsonld",
+  "@id": "https://example.com/ujg/checkout-with-exit.jsonld",
+  "@type": "UJGDocument",
+  "nodes": [
+    {
+      "@type": "Journey",
+      "@id": "urn:ujg:journey:shop",
+      "label": "Shop journey",
+      "startStateRef": "urn:ujg:state:cart",
+      "stateRefs": [
+        "urn:ujg:state:cart",
+        "urn:ujg:state:checkout-flow",
+        "urn:ujg:state:confirmation"
+      ],
+      "transitionRefs": [
+        "urn:ujg:transition:cart-to-checkout",
+        "urn:ujg:transition:checkout-to-confirmation"
+      ]
+    },
+    {
+      "@type": "State",
+      "@id": "urn:ujg:state:cart",
+      "label": "Cart"
+    },
+    {
+      "@type": "CompositeState",
+      "@id": "urn:ujg:state:checkout-flow",
+      "label": "Checkout flow",
+      "subjourneyId": "urn:ujg:journey:checkout"
+    },
+    {
+      "@type": "State",
+      "@id": "urn:ujg:state:confirmation",
+      "label": "Confirmation"
+    },
+    {
+      "@type": "Transition",
+      "@id": "urn:ujg:transition:cart-to-checkout",
+      "label": "Start checkout",
+      "from": "urn:ujg:state:cart",
+      "to": "urn:ujg:state:checkout-flow"
+    },
+    {
+      "@type": "Transition",
+      "@id": "urn:ujg:transition:checkout-to-confirmation",
+      "label": "Show confirmation",
+      "from": "urn:ujg:state:checkout-flow",
+      "to": "urn:ujg:state:confirmation",
+      "fromExitRef": "urn:ujg:exit:checkout-complete"
+    },
+    {
+      "@type": "Journey",
+      "@id": "urn:ujg:journey:checkout",
+      "label": "Checkout child journey",
+      "startStateRef": "urn:ujg:state:checkout-form",
+      "stateRefs": [
+        "urn:ujg:state:checkout-form",
+        "urn:ujg:state:checkout-complete"
+      ],
+      "transitionRefs": [
+        "urn:ujg:transition:checkout-form-to-complete"
+      ],
+      "exitRefs": [
+        "urn:ujg:exit:checkout-complete"
+      ]
+    },
+    {
+      "@type": "State",
+      "@id": "urn:ujg:state:checkout-form",
+      "label": "Checkout form"
+    },
+    {
+      "@type": "BoundaryState",
+      "@id": "urn:ujg:state:checkout-complete",
+      "label": "Checkout complete"
+    },
+    {
+      "@type": "Transition",
+      "@id": "urn:ujg:transition:checkout-form-to-complete",
+      "label": "Submit checkout",
+      "from": "urn:ujg:state:checkout-form",
+      "to": "urn:ujg:state:checkout-complete"
+    },
+    {
+      "@type": "JourneyExit",
+      "@id": "urn:ujg:exit:checkout-complete",
+      "label": "Checkout complete",
+      "exitStateRef": "urn:ujg:state:checkout-complete"
+    }
+  ]
+}
+```
+
 ---
 
 ## OutgoingTransition {data-cop-concept="outgoing-transition"}
@@ -325,6 +534,17 @@ classDiagram
 
   OutgoingTransition --> State : to
   OutgoingTransition --> CompositeState : to
+```
+
+Example JSON node:
+
+```json
+{
+  "@type": "OutgoingTransition",
+  "@id": "urn:ujg:ot:go-home",
+  "label": "Home",
+  "to": "urn:ujg:state:home"
+}
 ```
 
 ---
@@ -372,6 +592,19 @@ classDiagram
   OutgoingTransition --> CompositeState : to
 ```
 
+Example JSON node:
+
+```json
+{
+  "@type": "OutgoingTransitionGroup",
+  "@id": "urn:ujg:otg:global-header",
+  "outgoingTransitionRefs": [
+    "urn:ujg:ot:go-home",
+    "urn:ujg:ot:go-profile"
+  ]
+}
+```
+
 ---
 
 ## State-scoped Outgoing Affordances {data-cop-concept="state-scoped-outgoing"}
@@ -411,9 +644,7 @@ classDiagram
   note for BoundaryState "MUST NOT declare outgoingTransitionRefs"
 ```
 
-### Example: State-scoped Back to Home
-
-This example shows a search form state with a local "Back to home page" affordance. This is not a structural [=Transition=] from the SearchPage journey to the Root journey. It is a state-scoped navigational affordance. The `to` target must resolve to a known [=State=] or [=CompositeState=], but it does not need to be listed in the current journey's `stateRefs`.
+Example JSON nodes:
 
 ```json
 {
@@ -434,6 +665,8 @@ This example shows a search form state with a local "Back to home page" affordan
   "to": "urn:ujg:state:w3c-root-homepage"
 }
 ```
+
+This example shows a search form state with a local "Back to home page" affordance. This is not a structural [=Transition=] from the SearchPage journey to the Root journey. It is a state-scoped navigational affordance. The `to` target must resolve to a known [=State=] or [=CompositeState=], but it does not need to be listed in the current journey's `stateRefs`.
 
 ---
 

--- a/specs/ed/graph/index.md
+++ b/specs/ed/graph/index.md
@@ -109,16 +109,16 @@ Example JSON node:
 
 ## Journey {data-cop-concept="journey"}
 
-A [=Journey=] is the local container for intended flow topology. It lists the states that belong to the journey and the transitions that connect those states.
+A [=Journey=] is the local container for intended flow topology. It lists the states that belong to the journey and, when present, the transitions that connect those states.
 
 <spec-statement>
 1. A [=Journey=] **MUST** be identified by an IRI.
 2. A [=Journey=] **MUST** declare exactly one `startStateRef`.
 3. A [=Journey=] **MUST** declare at least one `stateRefs` value.
-4. A [=Journey=] **MUST** declare at least one `transitionRefs` value.
+4. A [=Journey=] **MAY** declare `transitionRefs`.
 5. Each `stateRefs` value **MUST** reference a [=State=] or a valid [=State=] subclass defined by this module.
-6. Each `transitionRefs` value **MUST** reference a [=Transition=].
-7. A [=Journey=] **MUST** consist of [=State|States=] connected by [=Transition|Transitions=].
+6. If present, each `transitionRefs` value **MUST** reference a [=Transition=].
+7. A [=Journey=] **MUST** contain one or more [=State|States=] and **MAY** connect those states with [=Transition|Transitions=].
 </spec-statement>
 
 ```mermaid
@@ -163,6 +163,20 @@ Example JSON node:
   ],
   "transitionRefs": [
     "urn:ujg:transition:search-form-to-results"
+  ]
+}
+```
+
+A single-state journey can omit `transitionRefs`:
+
+```json
+{
+  "@type": "Journey",
+  "@id": "urn:ujg:journey:privacy-policy",
+  "label": "Privacy policy",
+  "startStateRef": "urn:ujg:state:privacy-policy",
+  "stateRefs": [
+    "urn:ujg:state:privacy-policy"
   ]
 }
 ```
@@ -708,92 +722,7 @@ To ensure graph integrity, the following constraints **MUST** be met:
 
 ---
 
-
 ## Examples
-### Exported Exit JSON Example
-
-This example shows a parent journey with a `CompositeState`, a child journey, a child `JourneyExit`, and a parent transition that uses `fromExitRef`. The parent transition's `from` value is the parent-local `CompositeState`, its `to` value is a parent-local `State`, and its `fromExitRef` identifies the exported child journey exit. The parent transition does not reference the child state directly.
-
-```json
-{
-  "@context": "https://ujg.specs.openuji.org/ed/ns/context.jsonld",
-  "@id": "https://example.com/ujg/graph/w3c-search.jsonld",
-  "@type": "UJGDocument",
-  "nodes": [
-    {
-      "@type": "Journey",
-      "@id": "urn:ujg:journey:w3c-search",
-      "label": "W3C search journey",
-      "startStateRef": "urn:ujg:state:w3c-search-searchpage",
-      "stateRefs": ["urn:ujg:state:w3c-search-searchpage", "urn:ujg:state:w3c-search-results"],
-      "transitionRefs": ["urn:ujg:transition:w3c-search-searchpage-to-results"]
-    },
-    {
-      "@type": "CompositeState",
-      "@id": "urn:ujg:state:w3c-search-searchpage",
-      "label": "SearchPage",
-      "subjourneyId": "urn:ujg:journey:w3c-searchpage"
-    },
-    {
-      "@type": "State",
-      "@id": "urn:ujg:state:w3c-root-homepage",
-      "label": "Root homepage"
-    },
-    {
-      "@type": "State",
-      "@id": "urn:ujg:state:w3c-search-results",
-      "label": "Results"
-    },
-    {
-      "@type": "Transition",
-      "@id": "urn:ujg:transition:w3c-search-searchpage-to-results",
-      "label": "Search results",
-      "from": "urn:ujg:state:w3c-search-searchpage",
-      "to": "urn:ujg:state:w3c-search-results",
-      "fromExitRef": "urn:ujg:exit:w3c-searchpage-submitted"
-    },
-    {
-      "@type": "Journey",
-      "@id": "urn:ujg:journey:w3c-searchpage",
-      "label": "W3C search page journey",
-      "startStateRef": "urn:ujg:state:w3c-searchpage-form",
-      "stateRefs": ["urn:ujg:state:w3c-searchpage-form", "urn:ujg:state:w3c-searchpage-submitted"],
-      "transitionRefs": ["urn:ujg:transition:w3c-searchpage-form-to-submitted"],
-      "exitRefs": ["urn:ujg:exit:w3c-searchpage-submitted"]
-    },
-    {
-      "@type": "State",
-      "@id": "urn:ujg:state:w3c-searchpage-form",
-      "label": "Search form",
-      "outgoingTransitionRefs": ["urn:ujg:ot:w3c-searchpage-form-back-home"]
-    },
-    {
-      "@type": "BoundaryState",
-      "@id": "urn:ujg:state:w3c-searchpage-submitted",
-      "label": "Submitted"
-    },
-    {
-      "@type": "JourneyExit",
-      "@id": "urn:ujg:exit:w3c-searchpage-submitted",
-      "label": "Submitted",
-      "exitStateRef": "urn:ujg:state:w3c-searchpage-submitted"
-    },
-    {
-      "@type": "OutgoingTransition",
-      "@id": "urn:ujg:ot:w3c-searchpage-form-back-home",
-      "label": "Back to home page",
-      "to": "urn:ujg:state:w3c-root-homepage"
-    },
-    {
-      "@type": "Transition",
-      "@id": "urn:ujg:transition:w3c-searchpage-form-to-submitted",
-      "label": "Submit search form",
-      "from": "urn:ujg:state:w3c-searchpage-form",
-      "to": "urn:ujg:state:w3c-searchpage-submitted"
-    }
-  ]
-}
-```
 
 ### Combined JSON Example
 

--- a/specs/ed/graph/index.md
+++ b/specs/ed/graph/index.md
@@ -20,121 +20,246 @@ Examples in this page use an explicit context array composed from the published 
 - <dfn>CompositeState</dfn>: A state that encapsulates another [=Journey=] (sub-journey).
 - <dfn>BoundaryState</dfn>: A terminal [=State=] that represents an exported outcome of a [=Journey=].
 - <dfn>JourneyExit</dfn>: An exported boundary contract declared by a [=Journey=].
-- <dfn>OutgoingTransition</dfn>: A navigational affordance pointing to a next possible [=State=], [=CompositeState=], or [=BoundaryState=].
+- <dfn>OutgoingTransition</dfn>: A navigational affordance pointing to a next possible [=State=] or [=CompositeState=].
 - <dfn>OutgoingTransitionGroup</dfn>: A reusable set of outgoing transitions that a Consumer can treat as present on multiple states (e.g., global nav).
 
 ---
 
-## The Core Graph {data-cop-concept="core"}
+## State {data-cop-concept="state"}
 
-<spec-statement>A [=Journey=] **MUST** consist of [=State|States=] connected by [=Transition|Transitions=].</spec-statement>
+A [=State=] is the base graph node for a discrete point in an intended user experience, such as a page, screen, modal, or other user-visible step.
 
-### Visual Model
+Later sections define navigation affordances that can be attached to eligible states. This section defines only the base state node.
 
-```mermaid
-graph LR
-    A[State: Product] -->|Transition: Add| B[State: Cart]
-```
-
-## Composition (CompositeState) {data-cop-concept="composition"}
-
-Composition allows a node to reference an entire sub-journey, enabling "zoomable" graph interactions.
-
-### Visual Model
+<spec-statement>
+1. A [=State=] **MUST** be identified by an IRI.
+2. A [=State=] **MUST** declare exactly one `label`.
+3. A [=State=] **MAY** declare one or more `tags`.
+</spec-statement>
 
 ```mermaid
-graph LR
-    H[Home] --> C
-    subgraph C [Composite State: Checkout]
-      direction LR
-      s1[Shipping] --> s2[Payment]
-    end
-    C --> E[Exit]
+classDiagram
+  class State {
+    id
+    label
+    tags
+  }
 ```
-
-The structural definition of [=CompositeState=] and `subjourneyId` is normative in the ontology and validation artifacts. This section defines only how consumers interpret that structure as nested or zoomable journey composition.
-
-<spec-statement>A [=CompositeState=] **MUST** reference its nested graph through `subjourneyId` and **MUST NOT** list child states directly with `stateRefs`.</spec-statement>
 
 ---
 
-## Exported Journey Exits {data-cop-concept="journey-exits"}
+## Transition {data-cop-concept="transition"}
 
-A [=JourneyExit=] lets a child [=Journey=] export one or more named boundary exits. A parent [=Journey=] can then map each exported exit to a parent-local [=Transition=] from the [=CompositeState=] that references the child journey.
+A [=Transition=] is a structural directed edge between graph states. It models ordinary progression inside the local topology of a [=Journey=].
 
-A [=JourneyExit=] identifies one local [=BoundaryState=] of the declaring journey using `exitStateRef`. It allows an enclosing parent journey to distinguish which exported outcome of a nested child journey was reached without allowing the parent journey to reference child states directly.
+A [=Transition=] is not owned by either endpoint state. It is owned by a journey through `transitionRefs`.
 
-`exitRef` is a mapping property on a parent transition. It is not a transition endpoint. A transition's `from` and `to` values remain local to the enclosing journey.
-
-### Visual Model
+<spec-statement>
+1. A [=Transition=] **MUST** be identified by an IRI.
+2. A [=Transition=] **MUST** declare exactly one `from` value.
+3. A [=Transition=] **MUST** declare exactly one `to` value.
+4. The `from` and `to` values of a [=Transition=] **MUST** reference a [=State=] or a valid [=State=] subclass defined by this module.
+5. A [=Transition=] listed in a [=Journey=]'s `transitionRefs` **MUST** have `from` and `to` values listed in that same journey's `stateRefs`.
+6. A [=Transition=] **MUST NOT** use `from` or `to` to reference states belonging to another journey.
+7. A [=Transition=] **MUST NOT** declare more than one `label`.
+</spec-statement>
 
 ```mermaid
-graph LR
-    P1[Parent: SearchPage CompositeState] -->|exitRef: submitted| P2[Parent: Results]
+classDiagram
+  class State {
+    id
+    label
+  }
 
-    subgraph Child [Child Journey: SearchPage]
-      direction LR
-      C1[Search form] --> C2[Submitted boundary state]
-    end
+  class Transition {
+    id
+    label
+    from
+    to
+  }
 
-    P1 -. subjourneyId .-> Child
-    C2 -. exitStateRef .-> X[JourneyExit: submitted]
+  Transition --> State : from
+  Transition --> State : to
 ```
 
-### Conceptual Model
+---
+
+## Journey {data-cop-concept="journey"}
+
+A [=Journey=] is the local container for intended flow topology. It lists the states that belong to the journey and the transitions that connect those states.
+
+<spec-statement>
+1. A [=Journey=] **MUST** be identified by an IRI.
+2. A [=Journey=] **MUST** declare exactly one `startStateRef`.
+3. A [=Journey=] **MUST** declare at least one `stateRefs` value.
+4. A [=Journey=] **MUST** declare at least one `transitionRefs` value.
+5. Each `stateRefs` value **MUST** reference a [=State=] or a valid [=State=] subclass defined by this module.
+6. Each `transitionRefs` value **MUST** reference a [=Transition=].
+7. A [=Journey=] **MUST** consist of [=State|States=] connected by [=Transition|Transitions=].
+</spec-statement>
+
+```mermaid
+classDiagram
+  class Journey {
+    id
+    label
+    startStateRef
+    stateRefs
+    transitionRefs
+  }
+
+  class State {
+    id
+    label
+  }
+
+  class Transition {
+    id
+    from
+    to
+  }
+
+  Journey --> State : startStateRef
+  Journey --> State : stateRefs
+  Journey --> Transition : transitionRefs
+  Transition --> State : from
+  Transition --> State : to
+```
+
+---
+
+## CompositeState {data-cop-concept="composition"}
+
+A [=CompositeState=] is a [=State=] that represents nested composition. It references a child [=Journey=] through `subjourneyId`, allowing consumers to interpret the referenced journey as a zoomable or nested graph.
+
+The parent journey treats the [=CompositeState=] as a parent-local state. The parent journey does not list the child journey's states directly.
+
+<spec-statement>
+1. A [=CompositeState=] **MUST** be a [=State=].
+2. A [=CompositeState=] **MUST** declare exactly one `subjourneyId`.
+3. The `subjourneyId` value **MUST** resolve to a [=Journey=].
+4. A [=CompositeState=] **MUST NOT** list child states directly with `stateRefs`.
+</spec-statement>
+
+```mermaid
+classDiagram
+  class State
+  class CompositeState {
+    subjourneyId
+  }
+  class Journey {
+    stateRefs
+    transitionRefs
+  }
+
+  State <|-- CompositeState
+  Journey --> CompositeState : stateRefs
+  CompositeState --> Journey : subjourneyId
+```
+
+---
+
+## BoundaryState {data-cop-concept="boundary-state"}
+
+A [=BoundaryState=] is a terminal [=State=] that represents an exported outcome of a journey. A nested journey uses boundary states to expose completed outcomes to a parent journey through [=JourneyExit=].
+
+Boundary states remain local states of the journey that declares them.
+
+<spec-statement>
+1. A [=BoundaryState=] **MUST** be a [=State=].
+2. A [=BoundaryState=] **MUST NOT** also be a [=CompositeState=].
+3. A [=BoundaryState=] **MUST NOT** declare `subjourneyId`.
+4. A [=BoundaryState=] **MUST NOT** declare `outgoingTransitionRefs`.
+5. A [=BoundaryState=] listed in a [=Journey=]'s `stateRefs` **MUST NOT** be used as the `from` value of another [=Transition=] listed in that same journey's `transitionRefs`.
+6. Outgoing transition group injection **MUST NOT** create effective outgoing transitions from a [=BoundaryState=].
+</spec-statement>
+
+```mermaid
+classDiagram
+  class State
+  class BoundaryState {
+    terminalOutcome
+  }
+  class Journey {
+    stateRefs
+  }
+  class Transition {
+    from
+    to
+  }
+
+  State <|-- BoundaryState
+  Journey --> BoundaryState : stateRefs
+  Transition --> BoundaryState : to
+```
+
+---
+
+## JourneyExit {data-cop-concept="journey-exits"}
+
+A [=JourneyExit=] is an exported boundary contract declared by a [=Journey=]. It identifies one local [=BoundaryState=] using `exitStateRef`.
+
+A parent journey can use exported exits to distinguish which outcome of a child journey was reached, without directly referencing child states.
 
 <spec-statement>
 1. A [=Journey=] **MAY** declare `exitRefs`.
 2. Each value of `exitRefs` **MUST** reference a [=JourneyExit=].
 3. A [=JourneyExit=] **MUST** declare exactly one `exitStateRef`.
 4. The `exitStateRef` of a [=JourneyExit=] declared by a journey **MUST** reference a [=BoundaryState=] listed in that same journey's `stateRefs`.
-5. A [=JourneyExit=] **MUST** be declared by no more than one [=Journey=].
-6. A [=Journey=] **MUST NOT** list more than one [=JourneyExit=] with the same `exitStateRef`.
-</spec-statement>
-
-<spec-statement>
-1. A [=Transition=] **MAY** declare `exitRef`.
-2. A [=Transition=] **MUST NOT** declare more than one `exitRef`.
-3. A [=Transition=] with `exitRef` **MUST** have a `from` value that references a [=CompositeState=].
-4. The [=CompositeState=] referenced by `from` **MUST** declare exactly one `subjourneyId`.
-5. The `subjourneyId` value **MUST** resolve to a [=Journey=].
-6. The `exitRef` value **MUST** be listed in the `exitRefs` of the journey referenced by the `from` composite state's `subjourneyId`.
-7. `exitRef` **MUST NOT** weaken, replace, or bypass local transition endpoint validation.
-8. A transition's `from` and `to` values **MUST** continue to reference states, composite states, or boundary states listed in the enclosing journey's `stateRefs`.
-9. A parent transition **MUST NOT** directly reference a child journey's state as `from`, `to`, or through any child-state-specific transition property.
-10. A journey **MUST NOT** contain more than one transition with the same `from` value and the same `exitRef` value.
-</spec-statement>
-
-### BoundaryState
-
-<spec-statement>
-1. A [=BoundaryState=] represents an exported terminal outcome of a [=Journey=].
-2. A [=BoundaryState=] **MUST NOT** also be a [=CompositeState=].
-3. A [=BoundaryState=] **MUST NOT** declare `subjourneyId`.
-4. A [=BoundaryState=] **MUST NOT** declare `outgoingTransitionRefs`.
-5. A [=BoundaryState=] listed in a [=Journey=]'s `stateRefs` **MUST NOT** be used as the `from` value of another [=Transition=] listed in that same journey's `transitionRefs`.
-6. Outgoing transition group injection **MUST NOT** create effective outgoing transitions from a [=BoundaryState=].
-7. A [=JourneyExit=] `exitStateRef` **MUST** reference a [=BoundaryState=].
-8. A [=JourneyExit=] `exitStateRef` **MUST NOT** reference a [=CompositeState=].
-9. A [=JourneyExit=] **MUST NOT** be used for ordinary internal child transitions. Internal movement inside the child journey **MUST** continue to use normal [=Transition=] resources.
-10. Runtime observations, user actions, form values, clicked elements, submitted values, selected values, analytics facts, or other runtime facts **MUST NOT** be modeled in the Graph module through [=JourneyExit=]. Runtime facts remain outside the Graph module.
+5. A [=JourneyExit=] `exitStateRef` **MUST NOT** reference a [=CompositeState=].
+6. A [=JourneyExit=] **MUST** be declared by no more than one [=Journey=].
+7. A [=Journey=] **MUST NOT** list more than one [=JourneyExit=] with the same `exitStateRef`.
+8. A [=JourneyExit=] **MUST NOT** be used for ordinary internal child transitions.
+9. Runtime observations, user actions, form values, clicked elements, submitted values, selected values, analytics facts, or other runtime facts **MUST NOT** be modeled in the Graph module through [=JourneyExit=].
 </spec-statement>
 
 If a [=CompositeState=] completes and needs to export an outcome upward, the declaring journey SHOULD transition to a local [=BoundaryState=], and the [=JourneyExit=] SHOULD reference that [=BoundaryState=].
 
-### Processing Model
+```mermaid
+classDiagram
+  class Journey {
+    stateRefs
+    exitRefs
+  }
+  class BoundaryState
+  class JourneyExit {
+    exitStateRef
+  }
+
+  Journey --> BoundaryState : stateRefs
+  Journey --> JourneyExit : exitRefs
+  JourneyExit --> BoundaryState : exitStateRef
+```
+
+---
+
+## Parent Continuation with fromExitRef {data-cop-concept="parent-continuation"}
+
+`fromExitRef` is a mapping property on a parent [=Transition=]. It identifies which exported [=JourneyExit=] completed for the child journey of the transition's `from` [=CompositeState=].
+
+`fromExitRef` is not a transition endpoint. The transition's `from` and `to` values remain local to the enclosing journey.
+
+<spec-statement>
+1. A [=Transition=] **MAY** declare `fromExitRef`.
+2. A [=Transition=] **MUST NOT** declare more than one `fromExitRef`.
+3. A [=Transition=] with `fromExitRef` **MUST** have a `from` value that references a [=CompositeState=].
+4. The [=CompositeState=] referenced by `from` **MUST** declare exactly one `subjourneyId`.
+5. The `subjourneyId` value **MUST** resolve to a [=Journey=].
+6. The `fromExitRef` value **MUST** be listed in the `exitRefs` of the journey referenced by the `from` composite state's `subjourneyId`.
+7. `fromExitRef` **MUST NOT** weaken, replace, or bypass local transition endpoint validation.
+8. A parent transition **MUST NOT** directly reference a child journey's state as `from`, `to`, or through any child-state-specific transition property.
+9. A journey **MUST NOT** contain more than one transition with the same `from` value and the same `fromExitRef` value.
+</spec-statement>
 
 <spec-statement>
 When a Consumer enters a [=CompositeState=], it **MAY** resolve the composite state's `subjourneyId` and interpret the referenced child [=Journey=].
 
 If interpretation of the child journey reaches a [=BoundaryState=] that is the `exitStateRef` of a [=JourneyExit=] listed in that child journey's `exitRefs`, that [=JourneyExit=] becomes the exported exit of the child journey.
 
-If more than one [=JourneyExit=] listed by the same child journey has the same `exitStateRef`, the graph is invalid. A Consumer **MUST NOT** choose one arbitrarily.
-
 The enclosing journey may then continue only by taking a parent transition whose:
 
 1. `from` value is the active parent-local [=CompositeState=]; and
-2. `exitRef` value is the exported [=JourneyExit=].
+2. `fromExitRef` value is the exported [=JourneyExit=].
 
 If exactly one matching parent transition exists, the Consumer **MAY** continue to that transition's parent-local `to` state.
 
@@ -142,97 +267,153 @@ If no matching parent transition exists, the Consumer **MUST NOT** synthesize an
 
 If more than one matching parent transition exists, the graph is invalid. A Consumer **MUST NOT** choose one arbitrarily.
 
-A Consumer **MUST NOT** treat `exitRef` as a replacement for `from` or `to`.
+A Consumer **MUST NOT** treat `fromExitRef` as a replacement for `from` or `to`.
 
-A Consumer **MUST NOT** follow a parent transition whose `from` or `to` value is not listed in the enclosing journey's `stateRefs`.
-
-A Consumer **MUST NOT** treat a parent transition without `exitRef` as a fallback for an exported child journey exit.
+A Consumer **MUST NOT** treat a parent transition without `fromExitRef` as a fallback for an exported child journey exit.
 </spec-statement>
 
-<spec-statement>If a child journey declares `exitRefs` and reaches one of those exported exits, parent continuation for that exported exit **MUST** use a matching parent transition with `exitRef`. A parent transition without `exitRef` **MUST NOT** be treated as a fallback match for an exported child journey exit.</spec-statement>
+Use [=JourneyExit=] and `fromExitRef` when a nested journey has multiple explicit boundary outcomes that the parent journey needs to distinguish. Do not use [=JourneyExit=] for ordinary transitions inside the child journey; use normal child [=Transition=] resources for internal child movement.
 
-### Authoring Guidance
+```mermaid
+classDiagram
+  class Journey
+  class CompositeState {
+    subjourneyId
+  }
+  class BoundaryState
+  class JourneyExit
+  class Transition {
+    from
+    to
+    fromExitRef
+  }
 
-Use [=JourneyExit=] when a nested journey has multiple explicit boundary outcomes that the parent journey needs to distinguish. For example, a search form child journey may export `submitted`, `cancelled`, and `emptyQuery`; the parent journey can then map each exported exit to a different parent-level transition without referring directly to child states.
-
-Do not use [=JourneyExit=] for ordinary transitions inside the child journey. Use normal child [=Transition=] resources for internal child movement.
-
-When a nested journey reaches a completed outcome, model that outcome with a local [=BoundaryState=] and reference it from the appropriate [=JourneyExit=].
-
-Do not use [=JourneyExit=] when the parent transition intentionally treats the composite state as an undifferentiated whole. In that case, a normal transition from the [=CompositeState=] without `exitRef` remains sufficient, and the child journey should not require exported exits for that parent-level behavior.
+  CompositeState --> Journey : subjourneyId
+  Journey --> JourneyExit : exitRefs
+  JourneyExit --> BoundaryState : exitStateRef
+  Transition --> CompositeState : from
+  Transition --> JourneyExit : fromExitRef
+```
 
 ---
 
-## Reusability (OutgoingTransitionGroup) {data-cop-concept="reusability"}
+## OutgoingTransition {data-cop-concept="outgoing-transition"}
 
-An [=OutgoingTransitionGroup=] defines reusable outgoing transitions (e.g., headers/footers) to avoid duplicating common navigation across many states.
+An [=OutgoingTransition=] is a navigational affordance. It points to a possible target state but does not declare a structural transition in a journey's local topology.
 
-The structural definition of [=OutgoingTransitionGroup=] and [=OutgoingTransition=] is normative in the ontology and validation artifacts. This section defines only the consumer processing model for applying those reusable outgoing edges.
+An [=OutgoingTransition=] has no explicit `from` property. Its effective source comes from either a state-scoped `outgoingTransitionRefs` value or an injected [=OutgoingTransitionGroup=].
 
-### State-scoped Outgoing Transitions
+<spec-statement>
+1. An [=OutgoingTransition=] **MUST** be identified by an IRI.
+2. An [=OutgoingTransition=] **MUST** declare exactly one `to` value.
+3. `OutgoingTransition.to` **MAY** reference a resolvable [=State=] or [=CompositeState=] outside the journey that contributes the affordance.
+4. `OutgoingTransition.to` **MUST NOT** reference a [=BoundaryState=].
+5. An [=OutgoingTransition=] **MUST NOT** be listed in a [=Journey=]'s `transitionRefs`.
+6. An [=OutgoingTransition=] **MUST NOT** be used for ordinary internal journey progression when a local [=Transition=] is appropriate.
+7. An [=OutgoingTransition=] **MUST NOT** declare more than one `label`.
+</spec-statement>
+
+```mermaid
+classDiagram
+  class OutgoingTransition {
+    id
+    label
+    to
+  }
+  class State
+  class CompositeState
+
+  OutgoingTransition --> State : to
+  OutgoingTransition --> CompositeState : to
+```
+
+---
+
+## OutgoingTransitionGroup {data-cop-concept="outgoing-transition-group"}
+
+An [=OutgoingTransitionGroup=] defines a reusable set of outgoing affordances, such as header or footer navigation, that a Consumer can treat as present on multiple eligible states.
+
+Group injection does not add structural [=Transition=] resources to `transitionRefs`.
+
+<spec-statement>
+1. An [=OutgoingTransitionGroup=] **MUST** be identified by an IRI.
+2. An [=OutgoingTransitionGroup=] **MUST** declare at least one `outgoingTransitionRefs` value.
+3. Each group `outgoingTransitionRefs` value **MUST** reference an [=OutgoingTransition=].
+4. A [=Journey=] **MAY** reference an [=OutgoingTransitionGroup=] through `outgoingTransitionGroupRefs`.
+</spec-statement>
+
+<spec-statement>
+For journey-level group injection:
+
+1. The Consumer **MUST** resolve each referenced [=OutgoingTransitionGroup=] and each group `outgoingTransitionRefs` entry to an [=OutgoingTransition=].
+2. The Consumer **MUST** iterate over every [=State=] and [=CompositeState=] ID in `stateRefs` except [=BoundaryState=] instances.
+3. The Consumer **MUST** treat each iterated state as having an outgoing edge to every resolved [=OutgoingTransition=] `to`.
+4. The Consumer **MUST NOT** create effective outgoing transitions from a [=BoundaryState=].
+5. A Consumer **SHOULD** treat duplicate effective outgoing edges with the same effective source state and same [=OutgoingTransition=] `to` target as one effective edge.
+</spec-statement>
+
+```mermaid
+classDiagram
+  class Journey {
+    outgoingTransitionGroupRefs
+  }
+  class OutgoingTransitionGroup {
+    outgoingTransitionRefs
+  }
+  class OutgoingTransition {
+    to
+  }
+  class State
+  class CompositeState
+
+  Journey --> OutgoingTransitionGroup : outgoingTransitionGroupRefs
+  OutgoingTransitionGroup --> OutgoingTransition : outgoingTransitionRefs
+  OutgoingTransition --> State : to
+  OutgoingTransition --> CompositeState : to
+```
+
+---
+
+## State-scoped Outgoing Affordances {data-cop-concept="state-scoped-outgoing"}
+
+A [=State=] can also declare outgoing affordances directly. These affordances apply only to that state and are not injected into other states.
+
+Direct state-scoped affordances are for local navigational options, not for ordinary internal progression through a journey.
 
 <spec-statement>
 1. A [=State=] **MAY** declare `outgoingTransitionRefs`.
 2. A [=CompositeState=] **MUST NOT** declare `outgoingTransitionRefs`.
 3. A [=BoundaryState=] **MUST NOT** declare `outgoingTransitionRefs`.
-4. Each `outgoingTransitionRefs` value **MUST** reference an [=OutgoingTransition=].
-5. A state-scoped [=OutgoingTransition=] represents a navigational affordance available from the declaring [=State=] only. It does not declare a structural transition in the enclosing [=Journey=].
-6. The effective source of a state-scoped [=OutgoingTransition=] is the [=State=] that declares the `outgoingTransitionRefs` value.
-7. `OutgoingTransition.to` **MAY** reference a resolvable [=State=], [=CompositeState=], or [=BoundaryState=] outside the [=Journey=] that contains the declaring [=State=].
-8. A Consumer **MUST NOT** treat a state-scoped [=OutgoingTransition=] as a member of the enclosing [=Journey=]'s `transitionRefs`.
-9. State-scoped `outgoingTransitionRefs` **MUST NOT** be used for ordinary internal journey progression when a local [=Transition=] is appropriate.
+4. Each state-scoped `outgoingTransitionRefs` value **MUST** reference an [=OutgoingTransition=].
+5. The effective source of a state-scoped [=OutgoingTransition=] is the [=State=] that declares the `outgoingTransitionRefs` value.
+6. A Consumer **MUST NOT** treat a state-scoped [=OutgoingTransition=] as a member of the enclosing [=Journey=]'s `transitionRefs`.
+7. A Consumer **SHOULD** treat duplicate effective outgoing edges with the same effective source state and same [=OutgoingTransition=] `to` target as one effective edge.
 </spec-statement>
 
-A [=CompositeState=] represents nested composition through `subjourneyId`. If navigation should be available while a composite state is active, model it either as an [=OutgoingTransitionGroup=] referenced by the enclosing journey or as direct `outgoingTransitionRefs` on concrete states inside the composite state's subjourney.
-
-### Visual Model
+If navigation should be available while a [=CompositeState=] is active, model it either as an [=OutgoingTransitionGroup=] referenced by the enclosing journey or as direct `outgoingTransitionRefs` on concrete states inside the composite state's subjourney.
 
 ```mermaid
-graph TD
-    subgraph Global [Global Navigation]
-      direction LR
-      H[Target: Home]
-      P[Target: Profile]
-    end
+classDiagram
+  class State {
+    outgoingTransitionRefs
+  }
+  class CompositeState
+  class BoundaryState
+  class OutgoingTransition {
+    to
+  }
 
-    subgraph Flow [Checkout User Journey]
-      direction LR
-      S1[State: Shipping] -->|Explicit| S2[State: Payment]
-    end
+  State --> OutgoingTransition : outgoingTransitionRefs
+  OutgoingTransition --> State : to
+  OutgoingTransition --> CompositeState : to
 
-    S1 -.->|Outgoing| H
-    S1 -.->|Outgoing| P
-    S2 -.->|Outgoing| H
-    S2 -.->|Outgoing| P
-
-    linkStyle 1,2,3,4 stroke-dasharray: 5 5, stroke:green, color:green;
+  note for CompositeState "MUST NOT declare outgoingTransitionRefs"
+  note for BoundaryState "MUST NOT declare outgoingTransitionRefs"
 ```
-
-### Processing Model
-
-<spec-statement>
-When a Consumer computes effective outgoing affordances for a state in a [=Journey=], it **MUST** consider:
-
-1. [=OutgoingTransitionGroup=] resources referenced by the enclosing journey's `outgoingTransitionGroupRefs`; and
-2. `outgoingTransitionRefs` declared directly on the current [=State=].
-
-For journey-level group injection:
-
-1. **Resolution:** The Consumer **MUST** resolve each referenced [=OutgoingTransitionGroup=] and each group `outgoingTransitionRefs` entry to an [=OutgoingTransition=].
-2. **Iteration:** The Consumer **MUST** iterate over every [=State=] and [=CompositeState=] ID in `stateRefs` except [=BoundaryState=] instances.
-3. **Injection:** The Consumer **MUST** treat each iterated state as having an outgoing edge to every resolved [=OutgoingTransition=] `to`.
-4. **Boundary states:** The Consumer **MUST NOT** create effective outgoing transitions from a [=BoundaryState=].
-
-For state-level outgoing affordances:
-
-1. The Consumer **MUST** resolve each `outgoingTransitionRefs` value declared by the current [=State=] to an [=OutgoingTransition=].
-2. State-level `outgoingTransitionRefs` apply only to the [=State=] that declares them. They are not injected into other states.
-3. A Consumer **SHOULD** treat duplicate effective outgoing edges with the same effective source state and same [=OutgoingTransition=] `to` target as one effective edge.
-</spec-statement>
 
 ### Example: State-scoped Back to Home
 
-This example shows a search form state with a local "Back to home page" affordance. This is not a structural [=Transition=] from the SearchPage journey to the Root journey. It is a state-scoped navigational affordance. The `to` target must resolve to a known [=State=], [=CompositeState=], or [=BoundaryState=], but it does not need to be listed in the current journey's `stateRefs`.
+This example shows a search form state with a local "Back to home page" affordance. This is not a structural [=Transition=] from the SearchPage journey to the Root journey. It is a state-scoped navigational affordance. The `to` target must resolve to a known [=State=] or [=CompositeState=], but it does not need to be listed in the current journey's `stateRefs`.
 
 ```json
 {
@@ -258,7 +439,7 @@ This example shows a search form state with a local "Back to home page" affordan
 
 ## Ontology {data-cop-concept="ontology"}
 
-The normative Graph ontology is defined below and is published at `https://ujg.specs.openuji.org/ed/ns/graph`. It is the authoritative structural definition for Graph classes and properties, including `Journey`, `State`, `CompositeState`, `BoundaryState`, `Transition`, `JourneyExit`, `OutgoingTransition`, `OutgoingTransitionGroup`, `exitRefs`, `exitRef`, `exitStateRef`, and `outgoingTransitionRefs`.
+The normative Graph ontology is defined below and is published at `https://ujg.specs.openuji.org/ed/ns/graph`. It is the authoritative structural definition for Graph classes and properties, including `Journey`, `State`, `CompositeState`, `BoundaryState`, `Transition`, `JourneyExit`, `OutgoingTransition`, `OutgoingTransitionGroup`, `exitRefs`, `fromExitRef`, `exitStateRef`, and `outgoingTransitionRefs`.
 
 :::include ./graph.ttl :::
 
@@ -276,11 +457,15 @@ The normative Graph SHACL shape is defined below and is published at `https://uj
 
 :::include ./graph.shape.ttl :::
 
+---
+
+## Graph Integrity and Resolution {data-cop-concept="graph-integrity"}
+
 The rules below define additional graph integrity and resolution behavior beyond the structural constraints captured by the SHACL shape.
 
 <spec-statement>
 To ensure graph integrity, the following constraints **MUST** be met:
-1. **Reference Integrity:** All `startState`, `stateRefs`, `transitionRefs`, `exitRefs`, `outgoingTransitionGroupRefs`, and `outgoingTransitionRefs` IDs **MUST** resolve to valid Nodes within the current scope or imported modules.
+1. **Reference Integrity:** All `startStateRef`, `stateRefs`, `transitionRefs`, `exitRefs`, `outgoingTransitionGroupRefs`, and `outgoingTransitionRefs` IDs **MUST** resolve to valid Nodes within the current scope or imported modules.
 2. **Transition Endpoint Resolution:** The `from` and `to` IDs of a [=Transition=] **MUST** resolve to valid Nodes, and are required to be members of the enclosing [=Journey=]'s `stateRefs`. A transition **MUST NOT** reference states belonging to other journeys.
 3. **Composition Safety:** `subjourneyId` **MUST** resolve to a valid [=Journey=].
 4. **Journey Exit Resolution:** Every ID in `exitRefs` **MUST** resolve to a [=JourneyExit=].
@@ -290,33 +475,11 @@ To ensure graph integrity, the following constraints **MUST** be met:
 
 ---
 
-## Non-Goals {data-cop-concept="non-goals"}
 
-This module does **not** introduce cross-journey `from` or `to` endpoints.
+## Examples
+### Exported Exit JSON Example
 
-This module does **not** remove `Journey.transitionRefs` or move structural transitions onto states.
-
-This module does **not** allow parent transitions to directly reference states that are not listed in the parent journey's `stateRefs`.
-
-This module does **not** allow `Transition.from` or `Transition.to` to point outside the enclosing journey's `stateRefs`.
-
-This module does **not** replace `CompositeState.subjourneyId`.
-
-This module does **not** allow [=CompositeState=] to declare direct `outgoingTransitionRefs`.
-
-This module does **not** allow [=CompositeState=] as `JourneyExit.exitStateRef`.
-
-This module does **not** use [=OutgoingTransition=] for ordinary internal journey progression.
-
-This module does **not** model runtime facts such as submitted form data, typed query text, selected result, clicked button, observed user behavior, analytics events, or runtime conditions.
-
-This module does **not** introduce guards, conditions, priorities, fallback matching, or runtime event matching.
-
----
-
-## Appendix: Exported Exit JSON Example {.unnumbered}
-
-This example shows a parent journey with a `CompositeState`, a child journey, a child `JourneyExit`, and a parent transition that uses `exitRef`. The parent transition's `from` value is the parent-local `CompositeState`, its `to` value is a parent-local `State`, and its `exitRef` identifies the exported child journey exit. The parent transition does not reference the child state directly.
+This example shows a parent journey with a `CompositeState`, a child journey, a child `JourneyExit`, and a parent transition that uses `fromExitRef`. The parent transition's `from` value is the parent-local `CompositeState`, its `to` value is a parent-local `State`, and its `fromExitRef` identifies the exported child journey exit. The parent transition does not reference the child state directly.
 
 ```json
 {
@@ -328,7 +491,7 @@ This example shows a parent journey with a `CompositeState`, a child journey, a 
       "@type": "Journey",
       "@id": "urn:ujg:journey:w3c-search",
       "label": "W3C search journey",
-      "startState": "urn:ujg:state:w3c-search-searchpage",
+      "startStateRef": "urn:ujg:state:w3c-search-searchpage",
       "stateRefs": ["urn:ujg:state:w3c-search-searchpage", "urn:ujg:state:w3c-search-results"],
       "transitionRefs": ["urn:ujg:transition:w3c-search-searchpage-to-results"]
     },
@@ -354,13 +517,13 @@ This example shows a parent journey with a `CompositeState`, a child journey, a 
       "label": "Search results",
       "from": "urn:ujg:state:w3c-search-searchpage",
       "to": "urn:ujg:state:w3c-search-results",
-      "exitRef": "urn:ujg:exit:w3c-searchpage-submitted"
+      "fromExitRef": "urn:ujg:exit:w3c-searchpage-submitted"
     },
     {
       "@type": "Journey",
       "@id": "urn:ujg:journey:w3c-searchpage",
       "label": "W3C search page journey",
-      "startState": "urn:ujg:state:w3c-searchpage-form",
+      "startStateRef": "urn:ujg:state:w3c-searchpage-form",
       "stateRefs": ["urn:ujg:state:w3c-searchpage-form", "urn:ujg:state:w3c-searchpage-submitted"],
       "transitionRefs": ["urn:ujg:transition:w3c-searchpage-form-to-submitted"],
       "exitRefs": ["urn:ujg:exit:w3c-searchpage-submitted"]
@@ -399,7 +562,7 @@ This example shows a parent journey with a `CompositeState`, a child journey, a 
 }
 ```
 
-## Appendix: Combined JSON Example {.unnumbered}
+### Combined JSON Example
 
 ```json
 {
@@ -410,7 +573,7 @@ This example shows a parent journey with a `CompositeState`, a child journey, a 
     {
       "@type": "Journey",
       "@id": "urn:ujg:journey:main-site",
-      "startState": "urn:ujg:state:home",
+      "startStateRef": "urn:ujg:state:home",
       "stateRefs": ["urn:ujg:state:home", "urn:ujg:state:checkout-flow"],
       "transitionRefs": ["urn:ujg:transition:home-to-checkout"],
       "outgoingTransitionGroupRefs": ["urn:ujg:otg:global-header"]


### PR DESCRIPTION
## Summary

Updates the Graph Editor’s Draft to introduce `BoundaryState` and state-scoped outgoing affordances.

## Changes

- Added `BoundaryState` as a first-class graph class and JSON-LD term.
- Updated `JourneyExit.exitStateRef` to require a `BoundaryState`.
- Added direct `outgoingTransitionRefs` support for non-composite `State`.
- Prohibited direct `outgoingTransitionRefs` on `CompositeState` and `BoundaryState`.
- Updated Graph SHACL validation for the new constraints.
- Revised ED prose, processing model, non-goals, and examples.
- Updated the ED graph content manifest.
