### PR TITLE
add jounrey index

### DIFF
--- a/specs/ed/graph/content-manifest.json
+++ b/specs/ed/graph/content-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
   "publishedAt": "2026-02-14T16:41:32.000Z",
-  "updatedAt": "2026-06-12T10:37:57.341Z",
-  "contentHash": "sha256:b124d5b57a833bf733d8473b36274e56ba59296948b93e21c79b1a223324a0c0"
+  "updatedAt": "2026-06-15T10:16:06.873Z",
+  "contentHash": "sha256:532a3fbeaf9e15e39c89265e6b5044ffaec850683ebecf3f224c129824b3218d"
 }

--- a/specs/ed/graph/content-manifest.json
+++ b/specs/ed/graph/content-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
   "publishedAt": "2026-02-14T16:41:32.000Z",
-  "updatedAt": "2026-06-15T10:16:06.873Z",
-  "contentHash": "sha256:532a3fbeaf9e15e39c89265e6b5044ffaec850683ebecf3f224c129824b3218d"
+  "updatedAt": "2026-06-15T10:27:31.380Z",
+  "contentHash": "sha256:99cd6ec7a2fcba9d778b54b23aaf4edba137177147ea2d3891a4bb3cfbb40434"
 }

--- a/specs/ed/graph/content-manifest.json
+++ b/specs/ed/graph/content-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
   "publishedAt": "2026-02-14T16:41:32.000Z",
-  "updatedAt": "2026-06-15T10:27:31.380Z",
-  "contentHash": "sha256:99cd6ec7a2fcba9d778b54b23aaf4edba137177147ea2d3891a4bb3cfbb40434"
+  "updatedAt": "2026-06-15T10:32:55.515Z",
+  "contentHash": "sha256:e34eac68a0969e9ef58c098b241c2970d3834d654db247021a61e7bd03722401"
 }

--- a/specs/ed/graph/graph.context.jsonld
+++ b/specs/ed/graph/graph.context.jsonld
@@ -5,6 +5,7 @@
     "ujggraph": "https://ujg.specs.openuji.org/ed/ns/graph#",
 
     "Journey": "ujggraph:Journey",
+    "JourneyIndex": "ujggraph:JourneyIndex",
     "State": "ujggraph:State",
     "CompositeState": "ujggraph:CompositeState",
     "BoundaryState": "ujggraph:BoundaryState",

--- a/specs/ed/graph/graph.shape.ttl
+++ b/specs/ed/graph/graph.shape.ttl
@@ -29,6 +29,23 @@ ujggraphshape:OutgoingTargetShape a sh:NodeShape ;
     """ ;
   ] .
 
+ujggraphshape:IndexStateShape a sh:NodeShape ;
+  sh:nodeKind sh:IRI ;
+  sh:or (
+    [ sh:class ujggraph:State ]
+    [ sh:class ujggraph:CompositeState ]
+  ) ;
+  sh:sparql [
+    a sh:SPARQLConstraint ;
+    sh:message "JourneyIndex.stateRefs must not reference a BoundaryState." ;
+    sh:select """
+      SELECT $this
+      WHERE {
+        $this a ujggraph:BoundaryState .
+      }
+    """ ;
+  ] .
+
 ujggraphshape:JourneyShape a sh:NodeShape ;
   sh:targetClass ujggraph:Journey ;
   sh:nodeKind sh:IRI ;
@@ -289,6 +306,40 @@ ujggraphshape:JourneyShape a sh:NodeShape ;
         FILTER (?transition != ?otherTransition)
       }
     """ ;
+  ] .
+
+ujggraphshape:JourneyIndexShape a sh:NodeShape ;
+  sh:targetClass ujggraph:JourneyIndex ;
+  sh:nodeKind sh:IRI ;
+
+  sh:property [
+    sh:path ujggraph:stateRefs ;
+    sh:minCount 1 ;
+    sh:node ujggraphshape:IndexStateShape ;
+  ] ;
+
+  sh:property [
+    sh:path ujggraph:startStateRef ;
+    sh:maxCount 0 ;
+    sh:message "A JourneyIndex must not declare startStateRef." ;
+  ] ;
+
+  sh:property [
+    sh:path ujggraph:transitionRefs ;
+    sh:maxCount 0 ;
+    sh:message "A JourneyIndex must not declare transitionRefs." ;
+  ] ;
+
+  sh:property [
+    sh:path ujggraph:exitRefs ;
+    sh:maxCount 0 ;
+    sh:message "A JourneyIndex must not declare exitRefs." ;
+  ] ;
+
+  sh:property [
+    sh:path ujggraph:outgoingTransitionGroupRefs ;
+    sh:maxCount 0 ;
+    sh:message "A JourneyIndex must not declare outgoingTransitionGroupRefs." ;
   ] .
 
 ujggraphshape:StateShape a sh:NodeShape ;

--- a/specs/ed/graph/graph.shape.ttl
+++ b/specs/ed/graph/graph.shape.ttl
@@ -306,6 +306,37 @@ ujggraphshape:JourneyShape a sh:NodeShape ;
         FILTER (?transition != ?otherTransition)
       }
     """ ;
+  ] ;
+
+  sh:sparql [
+    a sh:SPARQLConstraint ;
+    sh:severity sh:Warning ;
+    sh:message "A state in Journey.stateRefs is not the start state, a local transition endpoint, or an exported exit state. Verify that it belongs to the journey's local topology and is not only a linked destination." ;
+    sh:select """
+      SELECT $this ?state
+      WHERE {
+        $this ujggraph:stateRefs ?state .
+
+        FILTER (NOT EXISTS {
+          $this ujggraph:startStateRef ?state .
+        })
+
+        FILTER (NOT EXISTS {
+          $this ujggraph:transitionRefs ?transition .
+          ?transition ujggraph:from ?state .
+        })
+
+        FILTER (NOT EXISTS {
+          $this ujggraph:transitionRefs ?transition .
+          ?transition ujggraph:to ?state .
+        })
+
+        FILTER (NOT EXISTS {
+          $this ujggraph:exitRefs ?exit .
+          ?exit ujggraph:exitStateRef ?state .
+        })
+      }
+    """ ;
   ] .
 
 ujggraphshape:JourneyIndexShape a sh:NodeShape ;
@@ -340,6 +371,42 @@ ujggraphshape:JourneyIndexShape a sh:NodeShape ;
     sh:path ujggraph:outgoingTransitionGroupRefs ;
     sh:maxCount 0 ;
     sh:message "A JourneyIndex must not declare outgoingTransitionGroupRefs." ;
+  ] ;
+
+  sh:property [
+    sh:path ujggraph:from ;
+    sh:maxCount 0 ;
+    sh:message "A JourneyIndex must not declare from." ;
+  ] ;
+
+  sh:property [
+    sh:path ujggraph:to ;
+    sh:maxCount 0 ;
+    sh:message "A JourneyIndex must not declare to." ;
+  ] ;
+
+  sh:property [
+    sh:path ujggraph:fromExitRef ;
+    sh:maxCount 0 ;
+    sh:message "A JourneyIndex must not declare fromExitRef." ;
+  ] ;
+
+  sh:property [
+    sh:path ujggraph:subjourneyId ;
+    sh:maxCount 0 ;
+    sh:message "A JourneyIndex must not declare subjourneyId." ;
+  ] ;
+
+  sh:property [
+    sh:path ujggraph:exitStateRef ;
+    sh:maxCount 0 ;
+    sh:message "A JourneyIndex must not declare exitStateRef." ;
+  ] ;
+
+  sh:property [
+    sh:path ujggraph:outgoingTransitionRefs ;
+    sh:maxCount 0 ;
+    sh:message "A JourneyIndex must not declare outgoingTransitionRefs." ;
   ] .
 
 ujggraphshape:StateShape a sh:NodeShape ;

--- a/specs/ed/graph/graph.ttl
+++ b/specs/ed/graph/graph.ttl
@@ -15,6 +15,11 @@
 ujggraph:Journey a owl:Class ;
   rdfs:subClassOf ujg:Node .
 
+ujggraph:JourneyIndex a owl:Class ;
+  rdfs:subClassOf ujg:Node ;
+  rdfs:label "Journey Index" ;
+  rdfs:comment "A catalogue of addressable journey entry states. A JourneyIndex does not define traversal, ordering, reachability, or parent-owned progression." .
+
 ujggraph:State a owl:Class ;
   rdfs:subClassOf ujg:Node .
 
@@ -58,7 +63,8 @@ ujggraph:startStateRef a owl:ObjectProperty ;
   rdfs:comment "References the start state of a journey." .
 
 ujggraph:stateRefs a owl:ObjectProperty ;
-  rdfs:range ujggraph:State .
+  rdfs:range ujggraph:State ;
+  rdfs:comment "References graph states. On Journey, stateRefs lists local topology states. On JourneyIndex, stateRefs lists addressable entry states without traversal semantics." .
 
 ujggraph:transitionRefs a owl:ObjectProperty ;
   rdfs:domain ujggraph:Journey ;

--- a/specs/ed/graph/index.md
+++ b/specs/ed/graph/index.md
@@ -1032,8 +1032,41 @@ The following source journey incorrectly lists `urn:ujg:state:profile-page` in `
   "@type": "UJGDocument",
   "nodes": [
     {
+      "@type": "JourneyIndex",
+      "@id": "urn:ujg:index:main-site-pages",
+      "label": "Main site pages",
+      "stateRefs": [
+        "urn:ujg:state:home-page",
+        "urn:ujg:state:checkout-flow",
+        "urn:ujg:state:profile-page"
+      ]
+    },
+
+    {
+      "@type": "CompositeState",
+      "@id": "urn:ujg:state:home-page",
+      "label": "Home page",
+      "subjourneyId": "urn:ujg:journey:home-page"
+    },
+
+    {
+      "@type": "CompositeState",
+      "@id": "urn:ujg:state:checkout-flow",
+      "label": "Checkout process",
+      "subjourneyId": "urn:ujg:journey:checkout"
+    },
+
+    {
+      "@type": "CompositeState",
+      "@id": "urn:ujg:state:profile-page",
+      "label": "Profile page",
+      "subjourneyId": "urn:ujg:journey:profile"
+    },
+
+    {
       "@type": "Journey",
-      "@id": "urn:ujg:journey:main-site",
+      "@id": "urn:ujg:journey:home-page",
+      "label": "Home page journey",
       "startStateRef": "urn:ujg:state:home",
       "stateRefs": ["urn:ujg:state:home", "urn:ujg:state:checkout-flow"],
       "transitionRefs": ["urn:ujg:transition:home-to-checkout"],
@@ -1056,25 +1089,44 @@ The following source journey incorrectly lists `urn:ujg:state:profile-page` in `
     },
 
     {
-      "@type": "CompositeState",
-      "@id": "urn:ujg:state:checkout-flow",
-      "label": "Checkout Process",
-      "subjourneyId": "urn:ujg:journey:checkout"
+      "@type": "Journey",
+      "@id": "urn:ujg:journey:checkout",
+      "label": "Checkout journey",
+      "startStateRef": "urn:ujg:state:checkout-cart",
+      "stateRefs": ["urn:ujg:state:checkout-cart"]
     },
 
-    { "@type": "State", "@id": "urn:ujg:state:profile", "label": "Profile" },
+    {
+      "@type": "State",
+      "@id": "urn:ujg:state:checkout-cart",
+      "label": "Checkout cart"
+    },
+
+    {
+      "@type": "Journey",
+      "@id": "urn:ujg:journey:profile",
+      "label": "Profile journey",
+      "startStateRef": "urn:ujg:state:profile-summary",
+      "stateRefs": ["urn:ujg:state:profile-summary"]
+    },
+
+    {
+      "@type": "State",
+      "@id": "urn:ujg:state:profile-summary",
+      "label": "Profile summary"
+    },
 
     {
       "@type": "OutgoingTransition",
       "@id": "urn:ujg:ot:go-home",
-      "to": "urn:ujg:state:home",
+      "to": "urn:ujg:state:home-page",
       "label": "Home"
     },
 
     {
       "@type": "OutgoingTransition",
       "@id": "urn:ujg:ot:go-profile",
-      "to": "urn:ujg:state:profile",
+      "to": "urn:ujg:state:profile-page",
       "label": "Profile"
     },
 

--- a/specs/ed/graph/index.md
+++ b/specs/ed/graph/index.md
@@ -14,7 +14,8 @@ Examples in this page use an explicit context array composed from the published 
 
 ## Terminology
 
-- <dfn>Journey</dfn>: A named container for a user flow.
+- <dfn>Journey</dfn>: A named container for local traversable user flow topology.
+- <dfn>JourneyIndex</dfn>: A catalogue of addressable journey entry states that does not define traversal.
 - <dfn>State</dfn>: A discrete node in the experience (e.g., a screen, modal).
 - <dfn>Transition</dfn>: A directed edge between two states.
 - <dfn>CompositeState</dfn>: A state that encapsulates another [=Journey=] (sub-journey).
@@ -111,6 +112,8 @@ Example JSON node:
 
 A [=Journey=] is the local container for intended flow topology. It lists the states that belong to the journey and, when present, the transitions that connect those states.
 
+Use [=Journey=] when the modeled object owns local traversal, progression, or structural order. If the model only needs to list known entry points into pages, surfaces, flows, or journeys, use [=JourneyIndex=] instead.
+
 <spec-statement>
 1. A [=Journey=] **MUST** be identified by an IRI.
 2. A [=Journey=] **MUST** declare exactly one `startStateRef`.
@@ -119,6 +122,9 @@ A [=Journey=] is the local container for intended flow topology. It lists the st
 5. Each `stateRefs` value **MUST** reference a [=State=] or a valid [=State=] subclass defined by this module.
 6. If present, each `transitionRefs` value **MUST** reference a [=Transition=].
 7. A [=Journey=] **MUST** contain one or more [=State|States=] and **MAY** connect those states with [=Transition|Transitions=].
+8. Every `stateRefs` value of a [=Journey=] **SHOULD** belong to that journey's local topology.
+9. A state belongs to a journey when it is the `startStateRef`, a `from` or `to` endpoint of a transition listed in that journey's `transitionRefs`, an exported boundary state referenced by a local [=JourneyExit=], or a local observable segment or condition connected by the journey's structural order.
+10. A [=Journey=] **SHOULD NOT** list a linked destination page, surface, flow, or journey entry inside `stateRefs` merely because an [=OutgoingTransition=] can reach it.
 </spec-statement>
 
 ```mermaid
@@ -180,6 +186,72 @@ A single-state journey can omit `transitionRefs`:
   ]
 }
 ```
+
+---
+
+## JourneyIndex {data-cop-concept="journey-index"}
+
+A [=JourneyIndex=] is a Graph class and Core [=Node=] that acts as a catalogue of addressable journey entry states. It is not a subclass of [=Journey=] and does not define traversal. A Consumer **MUST NOT** infer that indexed states are reachable from one another, ordered as a path, or part of a parent-owned progression.
+
+Use [=Journey=] when modeling local topology. Use [=JourneyIndex=] when listing known entry points into modeled journeys. A root [=Journey=] should only be used when the root itself owns real traversal, progression, or structural order.
+
+In common use, a [=JourneyIndex=] lists [=CompositeState=] entries whose `subjourneyId` values point to modeled pages, surfaces, flows, or journeys.
+
+<spec-statement>
+1. A [=JourneyIndex=] **MUST** be identified by an IRI.
+2. A [=JourneyIndex=] **MUST** declare at least one `stateRefs` value.
+3. Each `stateRefs` value **MUST** reference a resolvable [=State=] or [=CompositeState=].
+4. Each referenced state **MUST** be a top-level node in the same document or resolvable through imports.
+5. Each referenced state **SHOULD** be a [=CompositeState=] when it represents a page, surface, or nested journey entry.
+6. A [=JourneyIndex=] **MUST NOT** reference a [=BoundaryState=] in `stateRefs`.
+7. A [=JourneyIndex=] **MUST NOT** declare `startStateRef`.
+8. A [=JourneyIndex=] **MUST NOT** declare `transitionRefs`.
+9. A [=JourneyIndex=] **MUST NOT** declare `exitRefs`.
+10. A [=JourneyIndex=] **MUST NOT** declare `outgoingTransitionGroupRefs`.
+11. `stateRefs` on a [=JourneyIndex=] **MUST NOT** imply traversal order, reachability, user path, progression, or parent continuation.
+12. The order of values in `stateRefs` **MUST NOT** be interpreted normatively unless a future ordering mechanism is explicitly added.
+</spec-statement>
+
+[=JourneyIndex=] is intended for top-level page maps, product surface indexes, search-result target indexes, documentation indexes, route or catalogue manifests, and other collections of known journey entry points. Do not use [=JourneyIndex=] to model page-segment order, local journey progression, child completion, runtime observations, or experience annotations.
+
+```mermaid
+classDiagram
+  class JourneyIndex {
+    id
+    label
+    stateRefs
+  }
+
+  class State {
+    id
+    label
+  }
+
+  class CompositeState {
+    subjourneyId
+  }
+
+  JourneyIndex --> State : stateRefs
+  JourneyIndex --> CompositeState : stateRefs
+  CompositeState --> Journey : subjourneyId
+```
+
+Example JSON node:
+
+```json
+{
+  "@type": "JourneyIndex",
+  "@id": "urn:ujg:index:site-pages",
+  "label": "Site page index",
+  "stateRefs": [
+    "urn:ujg:state:home-page",
+    "urn:ujg:state:search-page",
+    "urn:ujg:state:profile-page"
+  ]
+}
+```
+
+The indexed states are known entry points. Their order above does not define a path from the home page to search to profile.
 
 ---
 
@@ -536,6 +608,8 @@ An [=OutgoingTransition=] has no explicit `from` property. Its effective source 
 7. An [=OutgoingTransition=] **MUST NOT** declare more than one `label`.
 </spec-statement>
 
+If the `to` target is a known page, surface, or flow entry, it should normally be listed in a [=JourneyIndex=]. Do not list that target in the source [=Journey=]'s `stateRefs` unless it also belongs to the source journey's local topology.
+
 ```mermaid
 classDiagram
   class OutgoingTransition {
@@ -680,13 +754,13 @@ Example JSON nodes:
 }
 ```
 
-This example shows a search form state with a local "Back to home page" affordance. This is not a structural [=Transition=] from the SearchPage journey to the Root journey. It is a state-scoped navigational affordance. The `to` target must resolve to a known [=State=] or [=CompositeState=], but it does not need to be listed in the current journey's `stateRefs`.
+This example shows a search form state with a local "Back to home page" affordance. This is not a structural [=Transition=] from the SearchPage journey to a root journey or [=JourneyIndex=]. It is a state-scoped navigational affordance. The `to` target must resolve to a known [=State=] or [=CompositeState=], but it does not need to be listed in the current journey's `stateRefs`. If the home page is a known page entry, it should normally be listed in a [=JourneyIndex=].
 
 ---
 
 ## Ontology {data-cop-concept="ontology"}
 
-The normative Graph ontology is defined below and is published at `https://ujg.specs.openuji.org/ed/ns/graph`. It is the authoritative structural definition for Graph classes and properties, including `Journey`, `State`, `CompositeState`, `BoundaryState`, `Transition`, `JourneyExit`, `OutgoingTransition`, `OutgoingTransitionGroup`, `exitRefs`, `fromExitRef`, `exitStateRef`, and `outgoingTransitionRefs`.
+The normative Graph ontology is defined below and is published at `https://ujg.specs.openuji.org/ed/ns/graph`. It is the authoritative structural definition for Graph classes and properties, including `Journey`, `JourneyIndex`, `State`, `CompositeState`, `BoundaryState`, `Transition`, `JourneyExit`, `OutgoingTransition`, `OutgoingTransitionGroup`, `exitRefs`, `fromExitRef`, `exitStateRef`, and `outgoingTransitionRefs`.
 
 :::include ./graph.ttl :::
 
@@ -714,15 +788,240 @@ The rules below define additional graph integrity and resolution behavior beyond
 To ensure graph integrity, the following constraints **MUST** be met:
 1. **Reference Integrity:** All `startStateRef`, `stateRefs`, `transitionRefs`, `exitRefs`, `outgoingTransitionGroupRefs`, and `outgoingTransitionRefs` IDs **MUST** resolve to valid Nodes within the current scope or imported modules.
 2. **Transition Endpoint Resolution:** The `from` and `to` IDs of a [=Transition=] **MUST** resolve to valid Nodes, and are required to be members of the enclosing [=Journey=]'s `stateRefs`. A transition **MUST NOT** reference states belonging to other journeys.
-3. **Composition Safety:** `subjourneyId` **MUST** resolve to a valid [=Journey=].
-4. **Journey Exit Resolution:** Every ID in `exitRefs` **MUST** resolve to a [=JourneyExit=].
-5. **Group Resolution:** Every ID in `outgoingTransitionGroupRefs` **MUST** resolve to an [=OutgoingTransitionGroup=].
-6. **Outgoing Resolution:** Every ID in `outgoingTransitionRefs` **MUST** resolve to an [=OutgoingTransition=].
+3. **JourneyIndex Resolution:** Every `stateRefs` ID in a [=JourneyIndex=] **MUST** resolve to a [=State=] or [=CompositeState=]. A [=JourneyIndex=]'s `stateRefs` **MUST NOT** imply reachability among entries.
+4. **Composition Safety:** `subjourneyId` **MUST** resolve to a valid [=Journey=].
+5. **Journey Exit Resolution:** Every ID in `exitRefs` **MUST** resolve to a [=JourneyExit=].
+6. **Group Resolution:** Every ID in `outgoingTransitionGroupRefs` **MUST** resolve to an [=OutgoingTransitionGroup=].
+7. **Outgoing Resolution:** Every ID in `outgoingTransitionRefs` **MUST** resolve to an [=OutgoingTransition=].
 </spec-statement>
 
 ---
 
 ## Examples
+
+### JourneyIndex with External Outgoing Target
+
+This example lists known page entries in a [=JourneyIndex=]. The search page journey has a state-scoped [=OutgoingTransition=] to the profile page entry, but the profile page is not part of the search page journey's local `stateRefs`.
+
+```json
+{
+  "@context": "https://ujg.specs.openuji.org/ed/ns/context.jsonld",
+  "@id": "https://example.com/ujg/graph/page-index.jsonld",
+  "@type": "UJGDocument",
+  "nodes": [
+    {
+      "@type": "JourneyIndex",
+      "@id": "urn:ujg:index:pages",
+      "label": "Page index",
+      "stateRefs": [
+        "urn:ujg:state:search-page",
+        "urn:ujg:state:profile-page"
+      ]
+    },
+    {
+      "@type": "CompositeState",
+      "@id": "urn:ujg:state:search-page",
+      "label": "Search page",
+      "subjourneyId": "urn:ujg:journey:search-page"
+    },
+    {
+      "@type": "CompositeState",
+      "@id": "urn:ujg:state:profile-page",
+      "label": "Profile page",
+      "subjourneyId": "urn:ujg:journey:profile-page"
+    },
+    {
+      "@type": "Journey",
+      "@id": "urn:ujg:journey:search-page",
+      "label": "Search page journey",
+      "startStateRef": "urn:ujg:state:search-form",
+      "stateRefs": [
+        "urn:ujg:state:search-form",
+        "urn:ujg:state:search-results"
+      ],
+      "transitionRefs": [
+        "urn:ujg:transition:search-form-to-results"
+      ]
+    },
+    {
+      "@type": "State",
+      "@id": "urn:ujg:state:search-form",
+      "label": "Search form"
+    },
+    {
+      "@type": "State",
+      "@id": "urn:ujg:state:search-results",
+      "label": "Search results",
+      "outgoingTransitionRefs": [
+        "urn:ujg:ot:search-results-to-profile"
+      ]
+    },
+    {
+      "@type": "Transition",
+      "@id": "urn:ujg:transition:search-form-to-results",
+      "label": "Submit search",
+      "from": "urn:ujg:state:search-form",
+      "to": "urn:ujg:state:search-results"
+    },
+    {
+      "@type": "OutgoingTransition",
+      "@id": "urn:ujg:ot:search-results-to-profile",
+      "label": "Open profile",
+      "to": "urn:ujg:state:profile-page"
+    },
+    {
+      "@type": "Journey",
+      "@id": "urn:ujg:journey:profile-page",
+      "label": "Profile page journey",
+      "startStateRef": "urn:ujg:state:profile-summary",
+      "stateRefs": [
+        "urn:ujg:state:profile-summary"
+      ]
+    },
+    {
+      "@type": "State",
+      "@id": "urn:ujg:state:profile-summary",
+      "label": "Profile summary"
+    }
+  ]
+}
+```
+
+### Form Child Journey with Parent Continuation
+
+This example models a form as a child journey. The form exports `submitted` through [=BoundaryState=] and [=JourneyExit=]. The enclosing journey continues from the form [=CompositeState=] to a result-page [=CompositeState=] using `fromExitRef`.
+
+```json
+{
+  "@context": "https://ujg.specs.openuji.org/ed/ns/context.jsonld",
+  "@id": "https://example.com/ujg/graph/form-continuation.jsonld",
+  "@type": "UJGDocument",
+  "nodes": [
+    {
+      "@type": "JourneyIndex",
+      "@id": "urn:ujg:index:form-example-pages",
+      "label": "Form example pages",
+      "stateRefs": [
+        "urn:ujg:state:contact-page",
+        "urn:ujg:state:result-page"
+      ]
+    },
+    {
+      "@type": "Journey",
+      "@id": "urn:ujg:journey:contact-page",
+      "label": "Contact page journey",
+      "startStateRef": "urn:ujg:state:contact-form",
+      "stateRefs": [
+        "urn:ujg:state:contact-form",
+        "urn:ujg:state:result-page"
+      ],
+      "transitionRefs": [
+        "urn:ujg:transition:contact-form-to-result"
+      ]
+    },
+    {
+      "@type": "CompositeState",
+      "@id": "urn:ujg:state:contact-page",
+      "label": "Contact page",
+      "subjourneyId": "urn:ujg:journey:contact-page"
+    },
+    {
+      "@type": "CompositeState",
+      "@id": "urn:ujg:state:contact-form",
+      "label": "Contact form",
+      "subjourneyId": "urn:ujg:journey:contact-form"
+    },
+    {
+      "@type": "CompositeState",
+      "@id": "urn:ujg:state:result-page",
+      "label": "Result page",
+      "subjourneyId": "urn:ujg:journey:result-page"
+    },
+    {
+      "@type": "Transition",
+      "@id": "urn:ujg:transition:contact-form-to-result",
+      "label": "Show result page",
+      "from": "urn:ujg:state:contact-form",
+      "to": "urn:ujg:state:result-page",
+      "fromExitRef": "urn:ujg:exit:contact-form-submitted"
+    },
+    {
+      "@type": "Journey",
+      "@id": "urn:ujg:journey:contact-form",
+      "label": "Contact form journey",
+      "startStateRef": "urn:ujg:state:contact-form-editing",
+      "stateRefs": [
+        "urn:ujg:state:contact-form-editing",
+        "urn:ujg:state:contact-form-submitted"
+      ],
+      "transitionRefs": [
+        "urn:ujg:transition:contact-form-submit"
+      ],
+      "exitRefs": [
+        "urn:ujg:exit:contact-form-submitted"
+      ]
+    },
+    {
+      "@type": "State",
+      "@id": "urn:ujg:state:contact-form-editing",
+      "label": "Contact form editing"
+    },
+    {
+      "@type": "BoundaryState",
+      "@id": "urn:ujg:state:contact-form-submitted",
+      "label": "Submitted"
+    },
+    {
+      "@type": "Transition",
+      "@id": "urn:ujg:transition:contact-form-submit",
+      "label": "Submit form",
+      "from": "urn:ujg:state:contact-form-editing",
+      "to": "urn:ujg:state:contact-form-submitted"
+    },
+    {
+      "@type": "JourneyExit",
+      "@id": "urn:ujg:exit:contact-form-submitted",
+      "label": "Submitted",
+      "exitStateRef": "urn:ujg:state:contact-form-submitted"
+    },
+    {
+      "@type": "Journey",
+      "@id": "urn:ujg:journey:result-page",
+      "label": "Result page journey",
+      "startStateRef": "urn:ujg:state:result-summary",
+      "stateRefs": [
+        "urn:ujg:state:result-summary"
+      ]
+    },
+    {
+      "@type": "State",
+      "@id": "urn:ujg:state:result-summary",
+      "label": "Result summary"
+    }
+  ]
+}
+```
+
+### Anti-Example: Linked Destination in Source Journey
+
+The following source journey incorrectly lists `urn:ujg:state:profile-page` in `stateRefs` merely because an outgoing affordance can reach it. The profile page should be listed in a [=JourneyIndex=] and referenced by `OutgoingTransition.to`; it should not be promoted into the search page journey's local topology.
+
+```json
+{
+  "@type": "Journey",
+  "@id": "urn:ujg:journey:search-page",
+  "label": "Search page journey",
+  "startStateRef": "urn:ujg:state:search-form",
+  "stateRefs": [
+    "urn:ujg:state:search-form",
+    "urn:ujg:state:search-results",
+    "urn:ujg:state:profile-page"
+  ],
+  "transitionRefs": [
+    "urn:ujg:transition:search-form-to-results"
+  ]
+}
+```
 
 ### Combined JSON Example
 

--- a/specs/ed/graph/index.md
+++ b/specs/ed/graph/index.md
@@ -124,7 +124,7 @@ Use [=Journey=] when the modeled object owns local traversal, progression, or st
 7. A [=Journey=] **MUST** contain one or more [=State|States=] and **MAY** connect those states with [=Transition|Transitions=].
 8. Every `stateRefs` value of a [=Journey=] **SHOULD** belong to that journey's local topology.
 9. A state belongs to a journey when it is the `startStateRef`, a `from` or `to` endpoint of a transition listed in that journey's `transitionRefs`, an exported boundary state referenced by a local [=JourneyExit=], or a local observable segment or condition connected by the journey's structural order.
-10. A [=Journey=] **SHOULD NOT** list a linked destination page, surface, flow, or journey entry inside `stateRefs` merely because an [=OutgoingTransition=] can reach it.
+10. A [=Journey=] **MUST NOT** list a linked destination page, surface, flow, or journey entry inside `stateRefs` merely because an [=OutgoingTransition=] can reach it.
 </spec-statement>
 
 ```mermaid
@@ -208,8 +208,14 @@ In common use, a [=JourneyIndex=] lists [=CompositeState=] entries whose `subjou
 8. A [=JourneyIndex=] **MUST NOT** declare `transitionRefs`.
 9. A [=JourneyIndex=] **MUST NOT** declare `exitRefs`.
 10. A [=JourneyIndex=] **MUST NOT** declare `outgoingTransitionGroupRefs`.
-11. `stateRefs` on a [=JourneyIndex=] **MUST NOT** imply traversal order, reachability, user path, progression, or parent continuation.
-12. The order of values in `stateRefs` **MUST NOT** be interpreted normatively unless a future ordering mechanism is explicitly added.
+11. A [=JourneyIndex=] **MUST NOT** declare `from`.
+12. A [=JourneyIndex=] **MUST NOT** declare `to`.
+13. A [=JourneyIndex=] **MUST NOT** declare `fromExitRef`.
+14. A [=JourneyIndex=] **MUST NOT** declare `subjourneyId`.
+15. A [=JourneyIndex=] **MUST NOT** declare `exitStateRef`.
+16. A [=JourneyIndex=] **MUST NOT** declare `outgoingTransitionRefs`.
+17. `stateRefs` on a [=JourneyIndex=] **MUST NOT** imply traversal order, reachability, user path, progression, or parent continuation.
+18. The order of values in `stateRefs` **MUST NOT** be interpreted normatively unless a future ordering mechanism is explicitly added.
 </spec-statement>
 
 [=JourneyIndex=] is intended for top-level page maps, product surface indexes, search-result target indexes, documentation indexes, route or catalogue manifests, and other collections of known journey entry points. Do not use [=JourneyIndex=] to model page-segment order, local journey progression, child completion, runtime observations, or experience annotations.

--- a/specs/ed/mapping/content-manifest.json
+++ b/specs/ed/mapping/content-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
   "publishedAt": "2026-02-13T10:12:45.000Z",
-  "updatedAt": "2026-06-09T16:01:06.351Z",
-  "contentHash": "sha256:44ecd48e6c3b7ddad45e4f2aa7488f888a88970065bca25f67fe02edb53b5536"
+  "updatedAt": "2026-06-15T10:16:06.873Z",
+  "contentHash": "sha256:361d58d142c951e855e3d0854e5de853f9b0d85ee060e156e0fd656e073702c7"
 }

--- a/specs/ed/mapping/index.md
+++ b/specs/ed/mapping/index.md
@@ -8,6 +8,10 @@ by resolving each `RuntimeEvent.stateRef` in the local journey scope supplied by
 `journeyInstanceRef`, then associating the resolved execution with an explicit root Graph
 `Journey`.
 
+Mapping roots are traversable Graph [=Journey|Journeys=]. A [=JourneyIndex=] can help discover known
+entry states before mapping, but it is not a local traversal scope and is not the target of
+`mappedJourneyRef`.
+
 Mapping surfaces model drift, tracking gaps, deep links, menu jumps, and other out-of-model
 movement. It does not assume every jump is an error.
 
@@ -25,7 +29,8 @@ with the Mapping context.
 ## Terminology
 
 - <dfn>JourneyMapping</dfn>: An addressable mapping record that binds one Runtime execution chain to
-  the root Graph `Journey` used to interpret it.
+  the root Graph `Journey` used to interpret it. The mapped journey is a traversable topology, not a
+  `JourneyIndex`.
 - <dfn>MappedStep</dfn>: An addressable mapping record for one `RuntimeEvent` in the mapped chain.
 - <dfn>Mapped runtime</dfn>: The `JourneyExecution` whose causal `RuntimeEvent` chain is being
   resolved.
@@ -96,6 +101,7 @@ the SHACL shape.
 5. **Journey ownership:** `mappedJourneyRef` identifies the root Graph `Journey` for the mapped
    execution. The root [=JourneyInstance=] of each mapped event's derived ancestor chain SHOULD
    reference the same Graph `Journey`.
+   `mappedJourneyRef` MUST NOT reference a [=JourneyIndex=].
 6. **Step order:** Mapping does not define a separate step order. Consumers MUST order mapped steps
    by applying Runtime chain reconstruction to each step's `mappedEventRef`.
 7. **Origin derivation:** The root event step is derived from the absence of

--- a/specs/ed/metrics/content-manifest.json
+++ b/specs/ed/metrics/content-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
   "publishedAt": "2025-12-29T13:54:26.000Z",
-  "updatedAt": "2026-06-09T16:13:01.683Z",
-  "contentHash": "sha256:1779f52f3401cfce2eb2d733dc02686a5ffacfc8c1d22b012628e9b5b6c1ad4b"
+  "updatedAt": "2026-06-15T10:16:06.873Z",
+  "contentHash": "sha256:a419547ff14be55eb118c7fcef7fdd75e67a0c2255337d020a65053b827ec5fd"
 }

--- a/specs/ed/metrics/index.md
+++ b/specs/ed/metrics/index.md
@@ -58,13 +58,16 @@ Mapping is the canonical interpretation layer for analytics over UJG execution d
 what happened, Graph defines the intended journey topology, and Mapping resolves each Runtime event
 to Graph state and transition intent.
 
+Mapping-derived journey metrics attach to traversable [=Journey=] scopes. A [=JourneyIndex=] is a
+discovery catalogue and does not itself define executions, movements, or traversal metrics.
+
 Mapping-derived metrics use these primary attachment points:
 
 | Attachment point | Meaning | Appropriate metrics |
 | --- | --- | --- |
 | [=JourneyMapping=] | One interpreted execution chain | `stepCount`, `movementCount`, `explainedMovementCount`, `unexplainedMovementCount`, `unexplainedMovementRate`, `boundaryCrossingCount`, `maxScopeDepth` |
 | [=MappedStep=] | One interpreted runtime event | boolean per-step observations such as whether the step is root, explained, or unexplained |
-| [=Journey=] | Aggregate over mappings resolved to this root journey | `executionCount`, `stepCount`, `unexplainedMovementRate`, `stateVisitCount`, `transitionTraversalCount` |
+| [=Journey=] | Aggregate over mappings resolved to this root traversable journey | `executionCount`, `stepCount`, `unexplainedMovementRate`, `stateVisitCount`, `transitionTraversalCount` |
 | [=State=] or [=CompositeState=] | Aggregate over mapped steps resolving to this state | `stateVisitCount`, `boundaryEntryCount`, `boundaryExitCount` |
 | [=Transition=] or [=OutgoingTransition=] | Aggregate over explained movements | `transitionTraversalCount`, `outgoingTraversalCount` |
 

--- a/specs/ed/runtime/content-manifest.json
+++ b/specs/ed/runtime/content-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
   "publishedAt": "2025-12-29T13:54:26.000Z",
-  "updatedAt": "2026-06-09T16:01:06.351Z",
-  "contentHash": "sha256:53e0063241ebbb2637a22afb5e3bba37e9681244fb16ea6e625cd36638818d80"
+  "updatedAt": "2026-06-15T10:16:06.873Z",
+  "contentHash": "sha256:f9ac0556b2c00f32b7aca65181fa94072ebcc4571cadd322a7f780d398682049"
 }

--- a/specs/ed/runtime/index.md
+++ b/specs/ed/runtime/index.md
@@ -18,7 +18,7 @@ Examples in this page use an explicit context array composed from the published 
 
 - <dfn>JourneyExecution</dfn>: A bounded execution identifier for one logical trace.
 - <dfn>RuntimeEvent</dfn>: An atomic record of a single observed runtime moment.
-- <dfn>JourneyInstance</dfn>: A concrete runtime occurrence of a graph [=Journey=].
+- <dfn>JourneyInstance</dfn>: A concrete runtime occurrence of a graph [=Journey=], not a [=JourneyIndex=].
 - <dfn>Event Chain</dfn>: A sequence where each event references its immediate predecessor via `previousId`.
 - <dfn>Root Event</dfn>: The event in a [=JourneyExecution=] whose `previousId` is omitted.
 
@@ -69,11 +69,11 @@ The core runtime-local address is the pair `RuntimeEvent.stateRef` plus `Runtime
 
 ## Journey Instance {data-cop-concept="journey-instance"}
 
-A [=JourneyInstance=] is a concrete runtime occurrence of a graph [=Journey=]. It is a scope node: it describes journey instantiation and nesting, not membership in an event stream.
+A [=JourneyInstance=] is a concrete runtime occurrence of a graph [=Journey=]. It is a scope node: it describes journey instantiation and nesting, not membership in an event stream. A [=JourneyIndex=] is not a runtime scope because it does not define traversal.
 
 <spec-statement>
 
-1. A [=JourneyInstance=] MUST reference exactly one graph [=Journey=] using `journeyRef`.
+1. A [=JourneyInstance=] MUST reference exactly one graph [=Journey=] using `journeyRef`; it MUST NOT reference a [=JourneyIndex=].
 2. A [=JourneyInstance=] MAY reference a parent [=JourneyInstance=] using `parentInstanceRef`.
 3. If a [=JourneyInstance=] represents a subjourney entered through a [=CompositeState=], it SHOULD provide `viaStateRef`.
 4. A [=JourneyInstance=] MUST NOT be required to reference a [=JourneyExecution=].


### PR DESCRIPTION
## Summary

Introduces `JourneyIndex` to the Graph Editor’s Draft as a non-traversal catalogue of addressable journey entry states.

## Changes

- Added `JourneyIndex` to Graph normative artifacts:
  - JSON-LD compact term
  - ontology class as a Core `Node`, not a `Journey`
  - SHACL shape requiring `stateRefs` and disallowing traversal-only Journey fields
- Updated Graph prose to clarify:
  - `Journey` remains for local traversable topology
  - `JourneyIndex` is for top-level page/surface/flow entry catalogues
  - `JourneyIndex.stateRefs` does not imply order, reachability, progression, or parent continuation
  - linked outgoing destinations should not be promoted into a source journey’s `stateRefs`
- Added examples for:
  - minimal/indexed page entries
  - outgoing transition to an indexed external composite
  - form child journey continuation via `BoundaryState`, `JourneyExit`, and `fromExitRef`
  - anti-example for incorrectly listing linked destinations in source `stateRefs`
- Clarified Runtime, Mapping, and Metrics prose so execution/mapping scopes remain traversable `Journey` instances, not `JourneyIndex`.
- Updated affected ED content manifests.

## Verification

- `pnpm content-manifests:check`
- `pnpm --filter @openuji/web lint`
- `pnpm build`