### PR TITLE
UJG-YAML

### DIFF
--- a/packages/ujg-yaml/README.md
+++ b/packages/ujg-yaml/README.md
@@ -1,0 +1,642 @@
+# @openuji/ujg-yaml
+
+Deterministic conversion between developer-oriented UJG authoring YAML and normalized canonical UJG JSON-LD.
+
+This package is intentionally a projection layer. The YAML format is not a second UJG specification. It is a nested, ordered, author-friendly representation that compiles into the project-selected canonical JSON-LD form used for JSON-LD expansion, RDF interpretation, SHACL, conformance checks, execution references, and interchange.
+
+## Status
+
+This package currently provides:
+
+- YAML authoring compile to canonical UJG JSON-LD.
+- Canonical JSON-LD projection back to strict literal `nodes:` YAML.
+- Locked target loading for `ed-2026-07-13`.
+- Generated target vocabulary derived from locked context, ontology, and SHACL artifacts.
+- Projection-registry validation against the generated target vocabulary.
+- Deterministic output ordering for nodes, set-valued arrays, and properties.
+- Structural round-trip validation.
+
+Known gaps:
+
+- Only the local Editor's Draft target `ed-2026-07-13` is registered today.
+- Immutable TR/snapshot targets such as `2026.06` are the intended next target class, but are not registered in this package yet.
+- Full JSON-LD expansion and RDF dataset comparison are not implemented yet.
+- SHACL and UJG conformance validation are not implemented yet.
+- Reverse projection intentionally emits no authoring sugar yet; it fails instead of guessing or dropping data.
+- The CLI `validate` command currently reports strict structural project/compile equivalence only.
+
+## Representations
+
+The package works with two explicit representations.
+
+Authoring YAML:
+
+```yaml
+ujgTarget: ed-2026-07-13
+touchpoints:
+  app:
+    label: App
+journey:
+  id: app-journey
+  defaultEntryRef: app-entry
+  entries:
+    app-entry:
+      stateRef: app-ready
+  states:
+    app-ready:
+      label: App ready
+      surface:
+        id: app-ready-surface
+        touchpointRef: app
+```
+
+Canonical JSON-LD:
+
+```json
+{
+  "@context": [
+    "https://ujg.specs.openuji.org/ed/ns/core.context.jsonld",
+    "https://ujg.specs.openuji.org/ed/ns/graph.context.jsonld",
+    "https://ujg.specs.openuji.org/ed/ns/surface.context.jsonld"
+  ],
+  "@id": "urn:ujg:document",
+  "@type": "UJGDocument",
+  "nodes": [
+    {
+      "@id": "app",
+      "@type": "Touchpoint",
+      "label": "App"
+    }
+  ]
+}
+```
+
+The exact canonical output contains all lifted nodes, sorted by `@id`.
+
+## How It Works
+
+### 1. Target Selection
+
+Every YAML document must declare a target:
+
+```yaml
+ujgTarget: ed-2026-07-13
+```
+
+The target is loaded from:
+
+- `targets/ed-2026-07-13.json`
+- `targets/ed-2026-07-13.vocab.json`
+
+The target JSON locks the source ED commit, context files, ontology files, and SHACL files by hash. The generated vocabulary JSON is derived from those locked artifacts and records the same artifact hashes.
+
+Runtime conversion does not fetch the current Editor's Draft and does not infer behavior from remote state. If the local artifacts or vocabulary lock are stale, target loading fails with `CONTEXT_NOT_LOCKED`.
+
+#### Editor's Draft Targets
+
+Targets whose id starts with `ed-` are special. They refer to a moving Editor's Draft, so the converter must not trust whatever happens to be online at runtime.
+
+For `ed-*` targets, the package expects the corresponding spec artifacts to exist in the local checkout under `specs/ed/...`. Target loading verifies those local files against the hashes recorded in the target lock. This means `ed-*` conversion works only when the local checkout contains the exact locked artifact contents.
+
+The check is content-based, not Git-branch-based:
+
+- a checkout at the recorded commit works;
+- a different checkout with identical artifact contents also works;
+- a checkout where any locked context, ontology, or SHACL file changed fails with `CONTEXT_NOT_LOCKED`;
+- a checkout missing the local `specs/ed/...` artifacts cannot satisfy the `ed-*` lock.
+
+The commit metadata in `targets/ed-2026-07-13.json` is provenance. The enforced lock is the artifact hash set.
+
+#### TR and Snapshot Targets
+
+Immutable published targets, for example a future target such as `2026.06`, should not require a local spec checkout.
+
+For those targets, the ontology, contexts, and SHACL artifacts are expected to be stable published resources. The target metadata can lock their public URLs and hashes, and the generated vocabulary can be produced from those immutable artifacts. Once such a target is registered, normal conversion should work from the package target files and generated vocabulary without requiring `specs/ed/...` to be checked out locally.
+
+In short:
+
+- `ed-*`: local Editor's Draft checkout required, verified by locked artifact hashes.
+- immutable snapshot/TR target: no local ED checkout should be required once the target is registered and its published artifacts are locked.
+
+### 2. Generated Target Vocabulary
+
+The generated vocabulary is created by:
+
+```sh
+pnpm -F @openuji/ujg-yaml run vocab:update
+```
+
+The generator reads the locked target artifacts:
+
+- `*.context.jsonld` for compact terms, `@id` references, `@set` containers, datatype hints, and context URLs.
+- `*.ttl` ontology files for classes, properties, and module ownership.
+- `*.shape.ttl` SHACL files for property-shape metadata such as `minCount`, `maxCount`, class/datatype hints, and node-kind hints.
+
+The generated file contains:
+
+- `classes`
+- `properties`
+- `modules`
+- `propertyShapes`
+- `referenceProperties`
+- `setProperties`
+- source artifact hashes
+
+The package uses this generated target vocabulary for:
+
+- supported class checks;
+- known property checks;
+- reference-property detection;
+- set-valued array normalization;
+- module and context selection;
+- projection-registry validation.
+
+### 3. Projection Registry
+
+`src/registry.js` contains authoring projection rules that cannot be derived from ontology alone.
+
+Examples:
+
+- `touchpoints` maps to `Touchpoint`.
+- `journeyEntryIndex` is a singleton section for `JourneyEntryIndex`.
+- `accessible.features` maps to `AccessibleFeature`.
+- nested `journey.states` lift into top-level canonical `nodes`.
+- nested `surface` produces a canonical `Surface` and synthesizes `graphNodeRef`.
+- `sampleScreenRef` is project-private YAML sugar stored under namespaced `extensions`.
+
+These rules are explicit and versioned. The ontology tells the converter what terms exist; the projection registry tells it how YAML authors express those terms.
+
+When a target is loaded, the projection registry is validated against the generated vocabulary. For example, if `touchpoints` maps to a class missing from the locked target vocabulary, conversion fails before compiling.
+
+### 4. Compile Flow
+
+`compileAuthoringYaml()` runs the following stages:
+
+1. Parse YAML with duplicate-key detection.
+2. Require `ujgTarget`.
+3. Load the target lock and generated vocabulary.
+4. Validate top-level authoring sections.
+5. Process registered keyed sections.
+6. Lift nested structural authoring forms into canonical nodes.
+7. Validate local references.
+8. Normalize canonical JSON-LD deterministically.
+9. Return the document and provenance.
+
+Important compile behaviors:
+
+- A keyed map key becomes `@id`.
+- Authoring `id` becomes `@id`.
+- Authoring `type` becomes `@type`.
+- Unknown top-level sections fail.
+- Unknown properties fail unless they are registered extension sugar.
+- Explicit types are accepted only if they exist in the generated target vocabulary.
+- Local references must resolve after lifting.
+- Absolute IRI references such as `https:`, `urn:`, and blank nodes are preserved as external references.
+- Set-valued arrays are deduplicated and sorted based on the generated vocabulary.
+- Order-sensitive arrays remain in authoring order.
+
+### 5. Structural Lifting
+
+The compiler lifts nested YAML definitions into top-level canonical `nodes`.
+
+Supported examples:
+
+```text
+CompositeState.subjourney
+  -> lift Journey
+  -> set subjourneyId on the CompositeState
+
+Journey.entries
+  -> lift JourneyEntry nodes
+  -> set entryRefs on the Journey
+
+Journey.states
+  -> lift State or CompositeState nodes
+  -> set stateRefs on the Journey
+
+Journey.transitions
+  -> lift Transition nodes
+  -> set transitionRefs on the Journey
+
+Graph node surface
+  -> lift Surface
+  -> set Surface.graphNodeRef to the owning graph node id
+```
+
+Nested state-local transitions are also lifted. The containing state id is used as the transition `from` value.
+
+### 6. Reverse Projection
+
+`projectCanonicalJsonLd()` projects canonical JSON-LD back to strict literal `nodes:` YAML.
+
+The reverse projection:
+
+- infers the target from the JSON-LD context, or uses `options.targetId`;
+- emits every canonical node as an item under top-level `nodes`;
+- uses `id` and `type` only as direct YAML spellings for `@id` and `@type`;
+- does not group, nest, omit types, infer ownership, or emit authoring sugar;
+- compiles the projected YAML and verifies the normalized node set is unchanged;
+- fails with `LOSSY_PROJECTION` when document-level data or node-local contexts would be dropped;
+- never recreates original comments, anchors, aliases, quoting, or original YAML key order.
+
+The result is deterministic normalized YAML, not the original source text.
+
+## CLI Usage
+
+The package exposes the `ujg-yaml` binary.
+
+From the workspace, use `pnpm exec` or the package filter.
+
+List targets:
+
+```sh
+pnpm -F @openuji/ujg-yaml exec ujg-yaml targets list
+```
+
+Compile authoring YAML to canonical JSON-LD:
+
+```sh
+pnpm -F @openuji/ujg-yaml exec ujg-yaml compile packages/ujg-yaml/fixtures/complex.yaml
+```
+
+Write compile output to a file:
+
+```sh
+pnpm -F @openuji/ujg-yaml exec ujg-yaml compile input.ujg.yaml -o output.ujg.jsonld
+```
+
+Write a compile provenance report:
+
+```sh
+pnpm -F @openuji/ujg-yaml exec ujg-yaml compile input.ujg.yaml -o output.ujg.jsonld --report report.json
+```
+
+Project canonical JSON-LD back to normalized YAML:
+
+```sh
+pnpm -F @openuji/ujg-yaml exec ujg-yaml project output.ujg.jsonld -o normalized.ujg.yaml
+```
+
+Run structural validation:
+
+```sh
+pnpm -F @openuji/ujg-yaml exec ujg-yaml validate output.ujg.jsonld
+```
+
+## Programmatic Usage
+
+Import from the package root:
+
+```js
+import {
+  compileAuthoringYaml,
+  listTargets,
+  loadTarget,
+  projectCanonicalJsonLd,
+  validateCanonicalJsonLd,
+} from '@openuji/ujg-yaml';
+```
+
+Compile YAML:
+
+```js
+import { readFile } from 'node:fs/promises';
+import { compileAuthoringYaml } from '@openuji/ujg-yaml';
+
+const source = await readFile('input.ujg.yaml', 'utf8');
+const result = await compileAuthoringYaml(source, {
+  filePath: 'input.ujg.yaml',
+});
+
+if (!result.ok) {
+  console.error(result.diagnostics);
+  process.exit(1);
+}
+
+console.log(JSON.stringify(result.document, null, 2));
+console.log(result.provenance);
+```
+
+Project JSON-LD:
+
+```js
+import { projectCanonicalJsonLd } from '@openuji/ujg-yaml';
+
+const result = await projectCanonicalJsonLd(canonicalDocument, {
+  targetId: 'ed-2026-07-13',
+});
+
+if (!result.ok) {
+  console.error(result.diagnostics);
+  process.exit(1);
+}
+
+console.log(result.yaml);
+```
+
+Validate JSON-LD structurally:
+
+```js
+import { validateCanonicalJsonLd } from '@openuji/ujg-yaml';
+
+const result = await validateCanonicalJsonLd(canonicalDocument);
+
+for (const diagnostic of result.diagnostics ?? []) {
+  console.error(`${diagnostic.severity} ${diagnostic.code}: ${diagnostic.message}`);
+}
+
+if (!result.ok) {
+  process.exit(1);
+}
+```
+
+Load target metadata and vocabulary:
+
+```js
+import { loadTarget } from '@openuji/ujg-yaml';
+
+const target = await loadTarget('ed-2026-07-13');
+
+console.log(Object.keys(target.vocabulary.classes));
+console.log(Object.keys(target.vocabulary.properties));
+```
+
+## API Reference
+
+### `compileAuthoringYaml(input, options)`
+
+Compiles UJG authoring YAML to canonical JSON-LD.
+
+Parameters:
+
+- `input`: YAML string.
+- `options.filePath`: optional path used in YAML syntax diagnostics.
+- `options.documentId`: optional fallback document `@id`.
+- `options.verifyArtifacts`: set to `false` to skip target artifact/vocabulary verification. This is useful only in tests or specialized tooling.
+
+Returns:
+
+```js
+{
+  ok: true,
+  document,
+  diagnostics,
+  provenance
+}
+```
+
+or:
+
+```js
+{
+  ok: false,
+  diagnostics
+}
+```
+
+### `projectCanonicalJsonLd(input, options)`
+
+Projects canonical JSON-LD to strict literal `nodes:` YAML and verifies `compile(project(canonical))` preserves the normalized node set.
+
+Parameters:
+
+- `input`: JSON string or object.
+- `options.targetId`: optional explicit target id. If omitted, the target is inferred from `@context`.
+- `options.verifyArtifacts`: optional target-verification override.
+
+Returns:
+
+```js
+{
+  ok: true,
+  authoring,
+  yaml,
+  diagnostics
+}
+```
+
+### `validateCanonicalJsonLd(input, options)`
+
+Runs strict structural project-compile-project validation.
+
+This currently does not run JSON-LD expansion, RDF dataset construction, or SHACL. On structural success it returns `ok: true` with no diagnostics.
+
+### `listTargets()`
+
+Returns the available locked target ids.
+
+### `loadTarget(targetId, options)`
+
+Loads target metadata, generated vocabulary, verifies artifact hashes, verifies vocabulary-lock consistency, and validates the projection registry against the target vocabulary.
+
+## Authoring YAML Shape
+
+### Top-Level Keys
+
+Supported top-level authoring sections include:
+
+- `ujgTarget`
+- `id` or `@id`
+- `nodes`
+- `touchpoints`
+- `actors`
+- `artifacts`
+- `actions`
+- `states`
+- `journeyEntryIndex`
+- `messageBundle`
+- `resolvers`
+- `observationBindings`
+- `phases`
+- `experienceSteps`
+- `journey`
+- `accessible`
+
+Unknown top-level keys fail with `UNKNOWN_AUTHORING_TERM`.
+
+### Keyed Sections
+
+Most sections are keyed maps:
+
+```yaml
+touchpoints:
+  app:
+    label: App
+```
+
+The key `app` becomes canonical `@id: "app"`.
+
+You can also use explicit `id` or `@id` inside node bodies. Duplicate canonical ids fail with `DUPLICATE_ID`.
+
+### Type Defaults
+
+Each registered section supplies a default type:
+
+```yaml
+actions:
+  submit:
+    label: Submit
+```
+
+compiles as:
+
+```json
+{
+  "@id": "submit",
+  "@type": "Action",
+  "label": "Submit"
+}
+```
+
+Explicit `type` is permitted when the target vocabulary contains that class:
+
+```yaml
+states:
+  checkout:
+    type: CompositeState
+    label: Checkout
+```
+
+### Accessibility Grouping
+
+Accessibility nodes are grouped under `accessible`:
+
+```yaml
+accessible:
+  features:
+    urn:feature:selected:
+      accessibleFeatureName: selected
+      accessibleFeatureValue: true
+  relations:
+    urn:relation:controls:
+      accessibleRelationType: controls
+      targetLocatorRef: urn:locator:target
+  locators:
+    urn:locator:submit:
+      role: button
+```
+
+Sugared authoring uses this grouping. Strict reverse projection currently emits accessibility nodes as literal `nodes:` entries rather than grouping them.
+
+### Extensions
+
+Project-private authoring sugar is registered in `EXTENSION_RULES`.
+
+For example:
+
+```yaml
+surface:
+  id: app-ready-surface
+  touchpointRef: app
+  sampleScreenRef: screens/app-ready.png
+```
+
+compiles into:
+
+```json
+{
+  "extensions": {
+    "https://openuji.org/ujg-yaml/extensions#sampleScreenRef": "screens/app-ready.png"
+  }
+}
+```
+
+Unregistered private data should be placed under namespaced `extensions` in canonical data.
+
+## Target Vocabulary Maintenance
+
+Update generated vocabulary after changing any locked context, ontology, SHACL, or target metadata:
+
+```sh
+pnpm -F @openuji/ujg-yaml run vocab:update
+```
+
+For the current `ed-2026-07-13` target, this command reads local locked artifacts from `specs/ed/...`. Run it from a checkout whose local ED files are intended to become the new lock.
+
+For future immutable TR/snapshot targets, vocabulary generation should use the registered snapshot artifact locations instead of the local moving ED tree. Those generated vocabularies should still be committed with the package so runtime conversion remains deterministic.
+
+Check that the generated vocabulary is up to date:
+
+```sh
+pnpm -F @openuji/ujg-yaml run vocab:check
+```
+
+Run full package checks:
+
+```sh
+pnpm -F @openuji/ujg-yaml check
+```
+
+The check command verifies:
+
+- JavaScript syntax for `src/*.js` and `scripts/*.js`;
+- deterministic generated vocabulary output.
+
+Run tests:
+
+```sh
+pnpm -F @openuji/ujg-yaml test
+```
+
+## Diagnostics
+
+The converter returns diagnostics instead of throwing for expected user-facing failures.
+
+Common codes:
+
+- `CONTEXT_NOT_LOCKED`: missing target, missing `ujgTarget`, stale target artifact lock, stale vocabulary lock, or an `ed-*` target whose required local checkout artifacts do not match the lock.
+- `YAML_SYNTAX`: YAML parser failure.
+- `DUPLICATE_KEY`: duplicate YAML key.
+- `UNKNOWN_AUTHORING_TERM`: unknown section or property.
+- `MISSING_ID`: addressable node missing an id.
+- `ID_CONFLICT`: keyed map entry has a body-level `id` or `@id` that does not match its map key.
+- `TYPE_CONFLICT`: unsupported target class.
+- `DUPLICATE_ID`: duplicate canonical `@id`.
+- `UNRESOLVED_REFERENCE`: local reference does not resolve after lifting.
+- `LOSSY_PROJECTION`: canonical JSON-LD cannot be projected to the current YAML form without dropping data.
+- `ROUND_TRIP_MISMATCH`: structural project/compile validation changed the normalized node set.
+
+Diagnostic objects generally include:
+
+```js
+{
+  code,
+  severity,
+  message,
+  file,
+  line,
+  column,
+  path,
+  id,
+  property,
+  reference,
+  remediation
+}
+```
+
+Not every diagnostic currently has every field.
+
+## Development Notes
+
+The key design boundary is:
+
+- Generated target vocabulary: facts derived from the locked UJG target.
+- Projection registry: explicit YAML authoring decisions.
+
+Do not add broad ontology facts back into `src/registry.js`. If a class, property, reference property, set property, module, or context URL is part of the UJG target, it should come from `targets/*.vocab.json`.
+
+Do keep authoring sugar explicit in `src/registry.js`. The ontology does not know the YAML spelling, section shape, structural nesting rules, or private extension sugar.
+
+## Fixtures
+
+Example inputs live in:
+
+- `fixtures/complex.yaml`
+- `fixtures/auth.yaml`
+
+These are useful for manual smoke tests:
+
+```sh
+pnpm -F @openuji/ujg-yaml exec ujg-yaml compile packages/ujg-yaml/fixtures/complex.yaml
+pnpm -F @openuji/ujg-yaml exec ujg-yaml compile packages/ujg-yaml/fixtures/auth.yaml
+```

--- a/packages/ujg-yaml/SKILL.md
+++ b/packages/ujg-yaml/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: ujg-authoring-canonical-converter
+description: "Implement and review deterministic conversion between developer-oriented UJG YAML and normalized canonical UJG JSON-LD without changing journey semantics."
+---
+
+# UJG Authoring ↔ Canonical Converter
+
+## Contract
+
+Use this skill for two explicit representations:
+
+- **Authoring representation — YAML** (`*.ujg.yaml`): nested, ordered, comment-friendly developer input.
+- **Canonical UJG instance — JSON-LD** (`*.ujg.jsonld`): normalized compact JSON-LD used for expansion, RDF interpretation, SHACL, conformance, execution references, and interchange.
+
+The YAML is a projection of UJG, not a second specification.
+
+Here, **canonical** means the project-selected normalized JSON-LD form. It does not mean RDF Dataset Canonicalization or a cryptographic canonical form.
+
+The converter projects syntax. It must not remodel, repair, or reinterpret the journey.
+
+## Semantic invariant
+
+```text
+Authoring YAML --compile--> Canonical JSON-LD
+Canonical JSON-LD --project--> Normalized authoring YAML
+```
+
+Correctness is RDF dataset equivalence, not byte equality:
+
+```text
+dataset(compile(project(canonical))) ≅ dataset(canonical)
+```
+
+Comments, anchors, aliases, quoting, and original key order are authoring metadata. Preserve them only in the YAML source or a source map; never pretend they can be reconstructed from JSON-LD.
+
+## Versioned projection registry
+
+Implement all authoring sugar through one explicit, versioned registry. Never infer classes from IRI prefixes or labels.
+
+Use **key equivalence** for dedicated class sections: the YAML key is the lower-camel-case form of the canonical class name. Cardinality is defined by the registry, not by singular or plural spelling.
+
+```text
+journeyEntryIndex     -> JourneyEntryIndex
+messageBundle         -> MessageBundle
+touchpoints           -> Touchpoint
+actors                -> Actor
+artifacts             -> project-defined Artifact default
+actions               -> Action
+states                -> State, unless explicit type overrides
+resolvers             -> SurfaceInstanceResolver
+observationBindings   -> ObservationBinding
+phases                -> Phase
+experienceSteps       -> ExperienceStep
+```
+
+Accessibility definitions are grouped under one authoring namespace:
+
+```yaml
+accessible:
+  features:
+    urn:feature:example:
+      accessibleFeatureName: selected
+      accessibleFeatureValue: true
+  relations:
+    urn:relation:example:
+      accessibleRelationType: controls
+      targetLocatorRef: urn:locator:target
+  locators:
+    urn:locator:example:
+      role: button
+```
+
+The nested mappings are fixed:
+
+```text
+accessible.features   -> AccessibleFeature
+accessible.relations  -> AccessibleRelation
+accessible.locators   -> AccessibleLocator, unless explicit type overrides
+```
+
+Do not accept top-level `features`, `relations`, or `locators` in the normalized authoring form. A migration reader may accept them temporarily, but the writer must always emit the `accessible` grouping.
+
+A keyed-map key becomes `@id`. Authoring `id` becomes `@id`; `type` becomes `@type`. Explicit types must be permitted at that position. Unknown sections, properties, and types fail by default. Private data stays under namespaced `extensions`.
+
+## Structural lifting
+
+All addressable definitions become top-level canonical `nodes`.
+
+```text
+CompositeState.subjourney
+  -> lift Journey
+  -> replace with subjourneyId
+
+Journey.entries
+  -> lift JourneyEntry nodes
+  -> create entryRefs
+
+Journey.states
+  -> lift State or CompositeState nodes
+  -> create stateRefs
+
+Journey.transitions
+  -> lift Transition nodes
+  -> create transitionRefs
+
+GraphNode.surface
+  -> lift Surface
+  -> set graphNodeRef to the owning Graph node @id
+```
+
+Register equivalent rules for exits, outgoing transitions, groups, and other supported nesting.
+
+Only synthesize projection mechanics: inferred default `@type`, ownership reference arrays, and `Surface.graphNodeRef`. Never invent missing messages, locators, surfaces, resolvers, states, transitions, outcomes, or references.
+
+## References and identity
+
+Treat registered `*Ref`, `*Refs`, `from`, and `to` properties as IRI references.
+
+- Resolve shorthand only through explicit prefixes or an explicit base.
+- Never resolve by label or proximity.
+- Reject duplicate YAML keys before conversion.
+- Reject conflicting definitions of one `@id`.
+- Validate every local reference after lifting.
+- Preserve external IRIs without requiring local definitions.
+
+Use a CST-capable YAML parser when line/column diagnostics or comment-preserving authoring writes are required. Resolve anchors before projection and reject alias cycles.
+
+## Canonical JSON-LD normalization
+
+Emit one compact JSON-LD `UJGDocument` with explicit `@context`, `@id`, `@type`, and `nodes`. Every node has explicit `@id` and `@type`.
+
+Include Core and only the module contexts required by emitted terms. Normalize deterministically:
+
+```text
+contexts: fixed dependency order
+nodes: sort by @id
+set-valued arrays: deduplicate and sort by IRI
+order-sensitive arrays: preserve order
+properties: stable project-defined order
+YAML-only metadata: omit
+```
+
+Use context definitions or the registry to distinguish set-valued from ordered properties. Never treat presentation `order` as Graph traversal or Runtime ordering.
+
+## Reverse projection
+
+Project JSON-LD back to YAML conservatively:
+
+- emit dedicated class sections using their registered lower-camel-case keys, including `journeyEntryIndex` and `messageBundle`;
+- emit `AccessibleFeature`, `AccessibleRelation`, and `AccessibleLocator` nodes only under `accessible.features`, `accessible.relations`, and `accessible.locators`;
+- group all other nodes by registered type;
+- nest a Journey under a CompositeState only when ownership is unambiguous;
+- nest entries, states, and transitions only when exactly one Journey owns them;
+- nest a Surface under its Graph node only when unambiguous;
+- keep shared or ambiguous nodes in their registered authoring sections;
+- omit `type` only where the registry supplies one unambiguous default;
+- never recreate comments or anchors from semantic data.
+
+The result must be deterministic, but it need not reproduce the original YAML text.
+
+## Validation and diagnostics
+
+Run stages in this order:
+
+```text
+1. YAML syntax, duplicate keys, and alias-cycle checks
+2. Authoring grammar validation
+3. Lifting, identity, ownership, and local-reference checks
+4. Canonical JSON-LD syntax and context checks
+5. JSON-LD expansion / RDF dataset construction
+6. UJG SHACL and conformance validation
+7. Optional semantic round-trip comparison
+```
+
+Never run UJG semantic validation directly against the nested YAML projection.
+
+Every error should include a stable code, severity, file/line/column, YAML path, canonical `@id` when known, affected property/reference, and concise remediation. Prefer codes such as:
+
+```text
+UNRESOLVED_REFERENCE
+DUPLICATE_ID
+TYPE_CONFLICT
+UNKNOWN_AUTHORING_TERM
+AMBIGUOUS_OWNERSHIP
+CONTEXT_NOT_LOCKED
+ROUND_TRIP_MISMATCH
+```
+
+## Reproducibility
+
+Keep the authoring grammar version separate from the UJG target:
+
+```yaml
+ujgTarget: ed-2026-07-13
+```
+
+Because the Editor's Draft moves, pin a dated target or lock exact context and SHACL artifact contents with hashes. Remote changes must not silently alter a build. Store converter provenance in a sidecar or build report, not as undocumented `UJGDocument` properties.
+
+## Required tests
+
+```text
+golden compile fixtures
+key-equivalence fixtures for journeyEntryIndex and messageBundle
+accessible grouping compile and reverse-projection fixtures
+legacy top-level accessibility-key migration behavior
+normalization idempotence
+compile-project-compile dataset equivalence
+unresolved-reference and duplicate-ID failures
+ambiguous-ownership projection
+unknown-term rejection
+context-lock reproducibility
+comments-and-anchors loss documentation
+```
+
+## Acceptance rule
+
+The converter is correct when it produces a deterministic, conforming JSON-LD instance with the same declared UJG meaning as the YAML, while reporting every unresolved semantic input and every lossy authoring-only feature explicitly.

--- a/packages/ujg-yaml/complex.jsonld
+++ b/packages/ujg-yaml/complex.jsonld
@@ -1,0 +1,699 @@
+{
+  "@id": "urn:ujg:document",
+  "@type": "UJGDocument",
+  "@context": [
+    "https://ujg.specs.openuji.org/ed/ns/core.context.jsonld",
+    "https://ujg.specs.openuji.org/ed/ns/graph.context.jsonld",
+    "https://ujg.specs.openuji.org/ed/ns/surface.context.jsonld",
+    "https://ujg.specs.openuji.org/ed/ns/action.context.jsonld",
+    "https://ujg.specs.openuji.org/ed/ns/artifact.context.jsonld",
+    "https://ujg.specs.openuji.org/ed/ns/distributed-journey.context.jsonld",
+    "https://ujg.specs.openuji.org/ed/ns/l10n.context.jsonld",
+    "https://ujg.specs.openuji.org/ed/ns/observability.context.jsonld"
+  ],
+  "nodes": [
+    {
+      "@id": "urn:action:alice-confirm-share",
+      "@type": "Action",
+      "label": "Alice confirms the remote share",
+      "producedArtifactRefs": [
+        "urn:artifact:federated-share"
+      ]
+    },
+    {
+      "@id": "urn:action:bob-accept-share",
+      "@type": "Action",
+      "label": "Bob accepts the incoming remote share",
+      "consumedArtifactRefs": [
+        "urn:artifact:federated-share"
+      ]
+    },
+    {
+      "@id": "urn:action:bob-open-accepted-file",
+      "@type": "Action",
+      "label": "Bob opens the accepted file",
+      "consumedArtifactRefs": [
+        "urn:artifact:federated-share"
+      ]
+    },
+    {
+      "@id": "urn:actor:alice",
+      "@type": "Actor",
+      "label": "Alice"
+    },
+    {
+      "@id": "urn:actor:bob",
+      "@type": "Actor",
+      "label": "Bob"
+    },
+    {
+      "@id": "urn:artifact:federated-share",
+      "@type": "DistributedArtifact",
+      "label": "Federated share for the test file",
+      "sourceTouchpointRef": "urn:touchpoint:nextcloud-a",
+      "targetTouchpointRefs": [
+        "urn:touchpoint:nextcloud-b"
+      ]
+    },
+    {
+      "@id": "urn:composite:alice-federated-sharing",
+      "@type": "CompositeState",
+      "label": "Alice federated sharing entry",
+      "subjourneyId": "urn:journey:alice-federated-sharing"
+    },
+    {
+      "@id": "urn:composite:bob-remote-share",
+      "@type": "CompositeState",
+      "label": "Bob remote-share entry",
+      "subjourneyId": "urn:journey:bob-remote-share"
+    },
+    {
+      "@id": "urn:entry:alice-federated-sharing",
+      "@type": "JourneyEntry",
+      "label": "Alice files entry",
+      "stateRef": "urn:state:alice-files-ready"
+    },
+    {
+      "@id": "urn:entry:bob-remote-share",
+      "@type": "JourneyEntry",
+      "label": "Bob incoming share entry",
+      "stateRef": "urn:state:bob-incoming-share-visible"
+    },
+    {
+      "@id": "urn:feature:artifact-instance-key",
+      "@type": "AccessibleFeature",
+      "label": "Artifact instance key",
+      "accessibleFeatureName": "file-id",
+      "accessibleFeatureValue": "*"
+    },
+    {
+      "@id": "urn:feature:remote-recipient-instance-key",
+      "@type": "AccessibleFeature",
+      "label": "Remote recipient instance key",
+      "accessibleFeatureName": "federated-cloud-id",
+      "accessibleFeatureValue": "*"
+    },
+    {
+      "@id": "urn:index:nextcloud-federated-sharing",
+      "@type": "JourneyEntryIndex",
+      "label": "Federated sharing local journey entries",
+      "stateRefs": [
+        "urn:composite:alice-federated-sharing",
+        "urn:composite:bob-remote-share"
+      ]
+    },
+    {
+      "@id": "urn:journey:alice-federated-sharing",
+      "@type": "Journey",
+      "label": "Alice shares a file with a remote recipient",
+      "defaultEntryRef": "urn:entry:alice-federated-sharing",
+      "entryRefs": [
+        "urn:entry:alice-federated-sharing"
+      ],
+      "stateRefs": [
+        "urn:state:alice-files-ready",
+        "urn:state:alice-remote-recipient-entered",
+        "urn:state:alice-share-confirmed",
+        "urn:state:alice-share-panel-open"
+      ],
+      "transitionRefs": [
+        "urn:transition:alice-confirms-share",
+        "urn:transition:alice-enters-remote-bob",
+        "urn:transition:alice-opens-file-menu"
+      ],
+      "exitRefs": [],
+      "outgoingTransitionGroupRefs": [],
+      "subjectActorRef": "urn:actor:alice"
+    },
+    {
+      "@id": "urn:journey:bob-remote-share",
+      "@type": "Journey",
+      "label": "Bob accepts an incoming remote share",
+      "defaultEntryRef": "urn:entry:bob-remote-share",
+      "entryRefs": [
+        "urn:entry:bob-remote-share"
+      ],
+      "stateRefs": [
+        "urn:state:bob-file-visible",
+        "urn:state:bob-incoming-share-visible",
+        "urn:state:bob-share-accepted"
+      ],
+      "transitionRefs": [
+        "urn:transition:bob-accepts-share",
+        "urn:transition:bob-opens-accepted-file"
+      ],
+      "exitRefs": [],
+      "outgoingTransitionGroupRefs": [],
+      "subjectActorRef": "urn:actor:bob"
+    },
+    {
+      "@id": "urn:locator:accepted-share-row",
+      "@type": "AccessibleLocator",
+      "label": "Accepted share row",
+      "role": "row",
+      "accessibleFeatureRefs": [
+        "urn:feature:artifact-instance-key"
+      ]
+    },
+    {
+      "@id": "urn:locator:alice-file-row",
+      "@type": "AccessibleLocator",
+      "label": "Alice target file row",
+      "role": "row",
+      "accessibleFeatureRefs": [
+        "urn:feature:artifact-instance-key"
+      ]
+    },
+    {
+      "@id": "urn:locator:alice-share-row",
+      "@type": "AccessibleLocator",
+      "label": "Confirmed outgoing share row",
+      "role": "row",
+      "accessibleFeatureRefs": [
+        "urn:feature:remote-recipient-instance-key"
+      ],
+      "contextLocatorRefs": [
+        "urn:locator:sharing-panel"
+      ]
+    },
+    {
+      "@id": "urn:locator:bob-accept-share-button",
+      "@type": "AccessibleLocator",
+      "label": "Bob accept share button",
+      "role": "button",
+      "accessibleNameRef": "urn:message:accept-action",
+      "contextLocatorRefs": [
+        "urn:locator:incoming-share-row"
+      ]
+    },
+    {
+      "@id": "urn:locator:bob-file-row",
+      "@type": "AccessibleLocator",
+      "label": "Bob accepted file row",
+      "role": "row",
+      "accessibleFeatureRefs": [
+        "urn:feature:artifact-instance-key"
+      ]
+    },
+    {
+      "@id": "urn:locator:bob-open-file-action",
+      "@type": "AccessibleLocator",
+      "label": "Bob open file action",
+      "role": "button",
+      "accessibleNameRef": "urn:message:open-action",
+      "contextLocatorRefs": [
+        "urn:locator:bob-file-row"
+      ]
+    },
+    {
+      "@id": "urn:locator:confirm-share-button",
+      "@type": "AccessibleLocator",
+      "label": "Confirm share button",
+      "role": "button",
+      "accessibleNameRef": "urn:message:confirm-share-action",
+      "contextLocatorRefs": [
+        "urn:locator:remote-recipient-entry"
+      ]
+    },
+    {
+      "@id": "urn:locator:file-share-action",
+      "@type": "AccessibleLocator",
+      "label": "File share action",
+      "role": "button",
+      "accessibleNameRef": "urn:message:share-action",
+      "contextLocatorRefs": [
+        "urn:locator:alice-file-row"
+      ]
+    },
+    {
+      "@id": "urn:locator:incoming-share-row",
+      "@type": "AccessibleLocator",
+      "label": "Incoming share row",
+      "role": "row",
+      "accessibleFeatureRefs": [
+        "urn:feature:artifact-instance-key"
+      ]
+    },
+    {
+      "@id": "urn:locator:remote-recipient-entry",
+      "@type": "AccessibleLocator",
+      "label": "Remote recipient result",
+      "role": "option",
+      "accessibleFeatureRefs": [
+        "urn:feature:remote-recipient-instance-key"
+      ],
+      "contextLocatorRefs": [
+        "urn:locator:sharing-panel"
+      ]
+    },
+    {
+      "@id": "urn:locator:remote-recipient-input",
+      "@type": "AccessibleLocator",
+      "label": "Remote recipient input",
+      "role": "textbox",
+      "accessibleNameRef": "urn:message:remote-recipient-input",
+      "contextLocatorRefs": [
+        "urn:locator:sharing-panel"
+      ]
+    },
+    {
+      "@id": "urn:locator:sharing-panel",
+      "@type": "AccessibleLocator",
+      "label": "Sharing panel",
+      "role": "complementary",
+      "accessibleNameRef": "urn:message:sharing-panel"
+    },
+    {
+      "@id": "urn:message:accept-action",
+      "@type": "MessageBundle",
+      "label": "Accept action",
+      "namespace": "nextcloud.actions",
+      "messageKey": "actions.accept",
+      "defaultLocale": "en",
+      "locales": {
+        "en": {
+          "value": "Accept"
+        }
+      }
+    },
+    {
+      "@id": "urn:message:confirm-share-action",
+      "@type": "MessageBundle",
+      "label": "Confirm share action",
+      "namespace": "nextcloud.actions",
+      "messageKey": "actions.confirmShare",
+      "defaultLocale": "en",
+      "locales": {
+        "en": {
+          "value": "Share"
+        }
+      }
+    },
+    {
+      "@id": "urn:message:open-action",
+      "@type": "MessageBundle",
+      "label": "Open action",
+      "namespace": "nextcloud.actions",
+      "messageKey": "actions.open",
+      "defaultLocale": "en",
+      "locales": {
+        "en": {
+          "value": "Open"
+        }
+      }
+    },
+    {
+      "@id": "urn:message:remote-recipient-input",
+      "@type": "MessageBundle",
+      "label": "Remote recipient input label",
+      "namespace": "nextcloud.sharing",
+      "messageKey": "sharing.remoteRecipientInput",
+      "defaultLocale": "en",
+      "locales": {
+        "en": {
+          "value": "Name, federated cloud ID or email address"
+        }
+      }
+    },
+    {
+      "@id": "urn:message:share-action",
+      "@type": "MessageBundle",
+      "label": "Share action",
+      "namespace": "nextcloud.actions",
+      "messageKey": "actions.share",
+      "defaultLocale": "en",
+      "locales": {
+        "en": {
+          "value": "Share"
+        }
+      }
+    },
+    {
+      "@id": "urn:message:sharing-panel",
+      "@type": "MessageBundle",
+      "label": "Sharing panel label",
+      "namespace": "nextcloud.sharing",
+      "messageKey": "sharing.panel",
+      "defaultLocale": "en",
+      "locales": {
+        "en": {
+          "value": "Sharing"
+        }
+      }
+    },
+    {
+      "@id": "urn:obs:alice-confirms-share-activation",
+      "@type": "ObservationBinding",
+      "label": "Activate Alice share confirmation",
+      "observeSurfaceRef": "urn:surface:alice-confirms-share",
+      "observationEventRef": "https://ujg.specs.openuji.org/ed/ns/observability#activation",
+      "locatorRefs": [
+        "urn:locator:confirm-share-button"
+      ],
+      "surfaceInstanceResolverRef": "urn:resolver:artifact-instance"
+    },
+    {
+      "@id": "urn:obs:alice-enters-remote-bob-activation",
+      "@type": "ObservationBinding",
+      "label": "Activate Alice remote recipient entry",
+      "observeSurfaceRef": "urn:surface:alice-enters-remote-bob",
+      "observationEventRef": "https://ujg.specs.openuji.org/ed/ns/observability#activation",
+      "locatorRefs": [
+        "urn:locator:remote-recipient-input"
+      ]
+    },
+    {
+      "@id": "urn:obs:alice-files-ready-presence",
+      "@type": "ObservationBinding",
+      "label": "Observe Alice files ready",
+      "observeSurfaceRef": "urn:surface:alice-files-ready",
+      "observationEventRef": "https://ujg.specs.openuji.org/ed/ns/observability#presence",
+      "locatorRefs": [
+        "urn:locator:alice-file-row"
+      ],
+      "surfaceInstanceResolverRef": "urn:resolver:artifact-instance"
+    },
+    {
+      "@id": "urn:obs:alice-opens-file-menu-activation",
+      "@type": "ObservationBinding",
+      "label": "Activate Alice share action",
+      "observeSurfaceRef": "urn:surface:alice-opens-file-menu",
+      "observationEventRef": "https://ujg.specs.openuji.org/ed/ns/observability#activation",
+      "locatorRefs": [
+        "urn:locator:file-share-action"
+      ],
+      "surfaceInstanceResolverRef": "urn:resolver:artifact-instance"
+    },
+    {
+      "@id": "urn:obs:alice-remote-recipient-entered-presence",
+      "@type": "ObservationBinding",
+      "label": "Observe Alice remote recipient entered",
+      "observeSurfaceRef": "urn:surface:alice-remote-recipient-entered",
+      "observationEventRef": "https://ujg.specs.openuji.org/ed/ns/observability#presence",
+      "locatorRefs": [
+        "urn:locator:remote-recipient-entry"
+      ]
+    },
+    {
+      "@id": "urn:obs:alice-share-confirmed-presence",
+      "@type": "ObservationBinding",
+      "label": "Observe Alice share confirmed",
+      "observeSurfaceRef": "urn:surface:alice-share-confirmed",
+      "observationEventRef": "https://ujg.specs.openuji.org/ed/ns/observability#presence",
+      "locatorRefs": [
+        "urn:locator:alice-share-row"
+      ],
+      "surfaceInstanceResolverRef": "urn:resolver:artifact-instance"
+    },
+    {
+      "@id": "urn:obs:alice-share-panel-open-presence",
+      "@type": "ObservationBinding",
+      "label": "Observe Alice share panel open",
+      "observeSurfaceRef": "urn:surface:alice-share-panel-open",
+      "observationEventRef": "https://ujg.specs.openuji.org/ed/ns/observability#presence",
+      "locatorRefs": [
+        "urn:locator:sharing-panel"
+      ]
+    },
+    {
+      "@id": "urn:obs:bob-accepts-share-activation",
+      "@type": "ObservationBinding",
+      "label": "Activate Bob share acceptance",
+      "observeSurfaceRef": "urn:surface:bob-accepts-share",
+      "observationEventRef": "https://ujg.specs.openuji.org/ed/ns/observability#activation",
+      "locatorRefs": [
+        "urn:locator:bob-accept-share-button"
+      ],
+      "surfaceInstanceResolverRef": "urn:resolver:artifact-instance"
+    },
+    {
+      "@id": "urn:obs:bob-file-visible-presence",
+      "@type": "ObservationBinding",
+      "label": "Observe Bob file visible",
+      "observeSurfaceRef": "urn:surface:bob-file-visible",
+      "observationEventRef": "https://ujg.specs.openuji.org/ed/ns/observability#presence",
+      "locatorRefs": [
+        "urn:locator:bob-file-row"
+      ],
+      "surfaceInstanceResolverRef": "urn:resolver:artifact-instance"
+    },
+    {
+      "@id": "urn:obs:bob-incoming-share-visible-presence",
+      "@type": "ObservationBinding",
+      "label": "Observe Bob incoming share",
+      "observeSurfaceRef": "urn:surface:bob-incoming-share-visible",
+      "observationEventRef": "https://ujg.specs.openuji.org/ed/ns/observability#presence",
+      "locatorRefs": [
+        "urn:locator:incoming-share-row"
+      ],
+      "surfaceInstanceResolverRef": "urn:resolver:artifact-instance"
+    },
+    {
+      "@id": "urn:obs:bob-opens-accepted-file-activation",
+      "@type": "ObservationBinding",
+      "label": "Activate Bob open accepted file",
+      "observeSurfaceRef": "urn:surface:bob-opens-accepted-file",
+      "observationEventRef": "https://ujg.specs.openuji.org/ed/ns/observability#activation",
+      "locatorRefs": [
+        "urn:locator:bob-open-file-action"
+      ],
+      "surfaceInstanceResolverRef": "urn:resolver:artifact-instance"
+    },
+    {
+      "@id": "urn:obs:bob-share-accepted-presence",
+      "@type": "ObservationBinding",
+      "label": "Observe Bob share accepted",
+      "observeSurfaceRef": "urn:surface:bob-share-accepted",
+      "observationEventRef": "https://ujg.specs.openuji.org/ed/ns/observability#presence",
+      "locatorRefs": [
+        "urn:locator:accepted-share-row"
+      ],
+      "surfaceInstanceResolverRef": "urn:resolver:artifact-instance"
+    },
+    {
+      "@id": "urn:phase:federated-access-established",
+      "@type": "Phase",
+      "label": "Federated access established",
+      "order": 2
+    },
+    {
+      "@id": "urn:phase:remote-share-offered",
+      "@type": "Phase",
+      "label": "Remote share offered",
+      "order": 1
+    },
+    {
+      "@id": "urn:resolver:artifact-instance",
+      "@type": "SurfaceInstanceResolver",
+      "label": "Resolve repeated artifact surface instances",
+      "instanceKeyFeatureRef": "urn:feature:artifact-instance-key"
+    },
+    {
+      "@id": "urn:state:alice-files-ready",
+      "@type": "State",
+      "label": "Alice files app is ready"
+    },
+    {
+      "@id": "urn:state:alice-remote-recipient-entered",
+      "@type": "State",
+      "label": "Alice entered Bob as a remote recipient"
+    },
+    {
+      "@id": "urn:state:alice-share-confirmed",
+      "@type": "State",
+      "label": "Alice confirmed the remote share"
+    },
+    {
+      "@id": "urn:state:alice-share-panel-open",
+      "@type": "State",
+      "label": "Alice sharing panel is open"
+    },
+    {
+      "@id": "urn:state:bob-file-visible",
+      "@type": "State",
+      "label": "Bob can see the shared file"
+    },
+    {
+      "@id": "urn:state:bob-incoming-share-visible",
+      "@type": "State",
+      "label": "Bob sees the pending remote share"
+    },
+    {
+      "@id": "urn:state:bob-share-accepted",
+      "@type": "State",
+      "label": "Bob accepted the remote share"
+    },
+    {
+      "@id": "urn:step:alice-share-confirmed",
+      "@type": "ExperienceStep",
+      "label": "Alice outgoing share confirmed",
+      "surfaceRefs": [
+        "urn:surface:alice-share-confirmed"
+      ],
+      "phaseRef": "urn:phase:remote-share-offered",
+      "order": 1
+    },
+    {
+      "@id": "urn:step:bob-file-visible",
+      "@type": "ExperienceStep",
+      "label": "Bob accepted file visible",
+      "surfaceRefs": [
+        "urn:surface:bob-file-visible"
+      ],
+      "phaseRef": "urn:phase:federated-access-established",
+      "order": 2
+    },
+    {
+      "@id": "urn:step:bob-incoming-share-visible",
+      "@type": "ExperienceStep",
+      "label": "Bob incoming share visible",
+      "surfaceRefs": [
+        "urn:surface:bob-incoming-share-visible"
+      ],
+      "phaseRef": "urn:phase:remote-share-offered",
+      "order": 2
+    },
+    {
+      "@id": "urn:step:bob-share-accepted",
+      "@type": "ExperienceStep",
+      "label": "Bob share accepted",
+      "surfaceRefs": [
+        "urn:surface:bob-share-accepted"
+      ],
+      "phaseRef": "urn:phase:federated-access-established",
+      "order": 1
+    },
+    {
+      "@id": "urn:surface:alice-confirms-share",
+      "@type": "Surface",
+      "label": "Alice confirm-share action",
+      "graphNodeRef": "urn:transition:alice-confirms-share",
+      "touchpointRef": "urn:touchpoint:nextcloud-a"
+    },
+    {
+      "@id": "urn:surface:alice-enters-remote-bob",
+      "@type": "Surface",
+      "label": "Alice remote recipient input",
+      "graphNodeRef": "urn:transition:alice-enters-remote-bob",
+      "touchpointRef": "urn:touchpoint:nextcloud-a"
+    },
+    {
+      "@id": "urn:surface:alice-files-ready",
+      "@type": "Surface",
+      "label": "Alice files list with target file",
+      "graphNodeRef": "urn:state:alice-files-ready",
+      "touchpointRef": "urn:touchpoint:nextcloud-a"
+    },
+    {
+      "@id": "urn:surface:alice-opens-file-menu",
+      "@type": "Surface",
+      "label": "Alice file share action",
+      "graphNodeRef": "urn:transition:alice-opens-file-menu",
+      "touchpointRef": "urn:touchpoint:nextcloud-a"
+    },
+    {
+      "@id": "urn:surface:alice-remote-recipient-entered",
+      "@type": "Surface",
+      "label": "Alice remote recipient entry",
+      "graphNodeRef": "urn:state:alice-remote-recipient-entered",
+      "touchpointRef": "urn:touchpoint:nextcloud-a"
+    },
+    {
+      "@id": "urn:surface:alice-share-confirmed",
+      "@type": "Surface",
+      "label": "Alice outgoing remote share is confirmed",
+      "graphNodeRef": "urn:state:alice-share-confirmed",
+      "touchpointRef": "urn:touchpoint:nextcloud-a"
+    },
+    {
+      "@id": "urn:surface:alice-share-panel-open",
+      "@type": "Surface",
+      "label": "Alice share panel for target file",
+      "graphNodeRef": "urn:state:alice-share-panel-open",
+      "touchpointRef": "urn:touchpoint:nextcloud-a"
+    },
+    {
+      "@id": "urn:surface:bob-accepts-share",
+      "@type": "Surface",
+      "label": "Bob accept-share action",
+      "graphNodeRef": "urn:transition:bob-accepts-share",
+      "touchpointRef": "urn:touchpoint:nextcloud-b"
+    },
+    {
+      "@id": "urn:surface:bob-file-visible",
+      "@type": "Surface",
+      "label": "Bob sees accepted file",
+      "graphNodeRef": "urn:state:bob-file-visible",
+      "touchpointRef": "urn:touchpoint:nextcloud-b"
+    },
+    {
+      "@id": "urn:surface:bob-incoming-share-visible",
+      "@type": "Surface",
+      "label": "Bob incoming remote share row",
+      "graphNodeRef": "urn:state:bob-incoming-share-visible",
+      "touchpointRef": "urn:touchpoint:nextcloud-b"
+    },
+    {
+      "@id": "urn:surface:bob-opens-accepted-file",
+      "@type": "Surface",
+      "label": "Bob open-file action",
+      "graphNodeRef": "urn:transition:bob-opens-accepted-file",
+      "touchpointRef": "urn:touchpoint:nextcloud-b"
+    },
+    {
+      "@id": "urn:surface:bob-share-accepted",
+      "@type": "Surface",
+      "label": "Bob accepted remote share",
+      "graphNodeRef": "urn:state:bob-share-accepted",
+      "touchpointRef": "urn:touchpoint:nextcloud-b"
+    },
+    {
+      "@id": "urn:touchpoint:nextcloud-a",
+      "@type": "Touchpoint",
+      "label": "Nextcloud A"
+    },
+    {
+      "@id": "urn:touchpoint:nextcloud-b",
+      "@type": "Touchpoint",
+      "label": "Nextcloud B"
+    },
+    {
+      "@id": "urn:transition:alice-confirms-share",
+      "@type": "Transition",
+      "label": "Alice confirms the share",
+      "from": "urn:state:alice-remote-recipient-entered",
+      "to": "urn:state:alice-share-confirmed",
+      "actionRef": "urn:action:alice-confirm-share"
+    },
+    {
+      "@id": "urn:transition:alice-enters-remote-bob",
+      "@type": "Transition",
+      "label": "Alice enters Bob's federated address",
+      "from": "urn:state:alice-share-panel-open",
+      "to": "urn:state:alice-remote-recipient-entered"
+    },
+    {
+      "@id": "urn:transition:alice-opens-file-menu",
+      "@type": "Transition",
+      "label": "Alice opens the sharing panel",
+      "from": "urn:state:alice-files-ready",
+      "to": "urn:state:alice-share-panel-open"
+    },
+    {
+      "@id": "urn:transition:bob-accepts-share",
+      "@type": "Transition",
+      "label": "Bob accepts the incoming share",
+      "from": "urn:state:bob-incoming-share-visible",
+      "to": "urn:state:bob-share-accepted",
+      "actionRef": "urn:action:bob-accept-share"
+    },
+    {
+      "@id": "urn:transition:bob-opens-accepted-file",
+      "@type": "Transition",
+      "label": "Bob opens the accepted shared file",
+      "from": "urn:state:bob-share-accepted",
+      "to": "urn:state:bob-file-visible",
+      "actionRef": "urn:action:bob-open-accepted-file"
+    }
+  ]
+}

--- a/packages/ujg-yaml/complex.yaml
+++ b/packages/ujg-yaml/complex.yaml
@@ -1,0 +1,415 @@
+ujgTarget: ed-2026-07-13
+actions:
+  urn:action:alice-confirm-share:
+    label: Alice confirms the remote share
+    producedArtifactRefs:
+      - urn:artifact:federated-share
+  urn:action:bob-accept-share:
+    label: Bob accepts the incoming remote share
+    consumedArtifactRefs:
+      - urn:artifact:federated-share
+  urn:action:bob-open-accepted-file:
+    label: Bob opens the accepted file
+    consumedArtifactRefs:
+      - urn:artifact:federated-share
+actors:
+  urn:actor:alice:
+    label: Alice
+  urn:actor:bob:
+    label: Bob
+artifacts:
+  urn:artifact:federated-share:
+    label: Federated share for the test file
+    sourceTouchpointRef: urn:touchpoint:nextcloud-a
+    targetTouchpointRefs:
+      - urn:touchpoint:nextcloud-b
+states:
+  urn:composite:alice-federated-sharing:
+    label: Alice federated sharing entry
+    subjourney:
+      label: Alice shares a file with a remote recipient
+      defaultEntryRef: urn:entry:alice-federated-sharing
+      subjectActorRef: urn:actor:alice
+      entries:
+        urn:entry:alice-federated-sharing:
+          label: Alice files entry
+          stateRef: urn:state:alice-files-ready
+          type: JourneyEntry
+      id: urn:journey:alice-federated-sharing
+      states:
+        urn:state:alice-files-ready:
+          label: Alice files app is ready
+          surface:
+            label: Alice files list with target file
+            touchpointRef: urn:touchpoint:nextcloud-a
+            id: urn:surface:alice-files-ready
+            type: Surface
+          transitions:
+            - label: Alice opens the sharing panel
+              to: urn:state:alice-share-panel-open
+              id: urn:transition:alice-opens-file-menu
+              surface:
+                label: Alice file share action
+                touchpointRef: urn:touchpoint:nextcloud-a
+                id: urn:surface:alice-opens-file-menu
+                type: Surface
+              type: Transition
+        urn:state:alice-remote-recipient-entered:
+          label: Alice entered Bob as a remote recipient
+          surface:
+            label: Alice remote recipient entry
+            touchpointRef: urn:touchpoint:nextcloud-a
+            id: urn:surface:alice-remote-recipient-entered
+            type: Surface
+          transitions:
+            - label: Alice confirms the share
+              to: urn:state:alice-share-confirmed
+              actionRef: urn:action:alice-confirm-share
+              id: urn:transition:alice-confirms-share
+              surface:
+                label: Alice confirm-share action
+                touchpointRef: urn:touchpoint:nextcloud-a
+                id: urn:surface:alice-confirms-share
+                type: Surface
+              type: Transition
+        urn:state:alice-share-confirmed:
+          label: Alice confirmed the remote share
+          surface:
+            label: Alice outgoing remote share is confirmed
+            touchpointRef: urn:touchpoint:nextcloud-a
+            id: urn:surface:alice-share-confirmed
+            type: Surface
+        urn:state:alice-share-panel-open:
+          label: Alice sharing panel is open
+          surface:
+            label: Alice share panel for target file
+            touchpointRef: urn:touchpoint:nextcloud-a
+            id: urn:surface:alice-share-panel-open
+            type: Surface
+          transitions:
+            - label: Alice enters Bob's federated address
+              to: urn:state:alice-remote-recipient-entered
+              id: urn:transition:alice-enters-remote-bob
+              surface:
+                label: Alice remote recipient input
+                touchpointRef: urn:touchpoint:nextcloud-a
+                id: urn:surface:alice-enters-remote-bob
+                type: Surface
+              type: Transition
+      type: Journey
+    type: CompositeState
+  urn:composite:bob-remote-share:
+    label: Bob remote-share entry
+    subjourney:
+      label: Bob accepts an incoming remote share
+      defaultEntryRef: urn:entry:bob-remote-share
+      subjectActorRef: urn:actor:bob
+      entries:
+        urn:entry:bob-remote-share:
+          label: Bob incoming share entry
+          stateRef: urn:state:bob-incoming-share-visible
+          type: JourneyEntry
+      id: urn:journey:bob-remote-share
+      states:
+        urn:state:bob-file-visible:
+          label: Bob can see the shared file
+          surface:
+            label: Bob sees accepted file
+            touchpointRef: urn:touchpoint:nextcloud-b
+            id: urn:surface:bob-file-visible
+            type: Surface
+        urn:state:bob-incoming-share-visible:
+          label: Bob sees the pending remote share
+          surface:
+            label: Bob incoming remote share row
+            touchpointRef: urn:touchpoint:nextcloud-b
+            id: urn:surface:bob-incoming-share-visible
+            type: Surface
+          transitions:
+            - label: Bob accepts the incoming share
+              to: urn:state:bob-share-accepted
+              actionRef: urn:action:bob-accept-share
+              id: urn:transition:bob-accepts-share
+              surface:
+                label: Bob accept-share action
+                touchpointRef: urn:touchpoint:nextcloud-b
+                id: urn:surface:bob-accepts-share
+                type: Surface
+              type: Transition
+        urn:state:bob-share-accepted:
+          label: Bob accepted the remote share
+          surface:
+            label: Bob accepted remote share
+            touchpointRef: urn:touchpoint:nextcloud-b
+            id: urn:surface:bob-share-accepted
+            type: Surface
+          transitions:
+            - label: Bob opens the accepted shared file
+              to: urn:state:bob-file-visible
+              actionRef: urn:action:bob-open-accepted-file
+              id: urn:transition:bob-opens-accepted-file
+              surface:
+                label: Bob open-file action
+                touchpointRef: urn:touchpoint:nextcloud-b
+                id: urn:surface:bob-opens-accepted-file
+                type: Surface
+              type: Transition
+      type: Journey
+    type: CompositeState
+accessible:
+  features:
+    urn:feature:artifact-instance-key:
+      label: Artifact instance key
+      accessibleFeatureName: file-id
+      accessibleFeatureValue: "*"
+    urn:feature:remote-recipient-instance-key:
+      label: Remote recipient instance key
+      accessibleFeatureName: federated-cloud-id
+      accessibleFeatureValue: "*"
+  locators:
+    urn:locator:accepted-share-row:
+      label: Accepted share row
+      role: row
+      accessibleFeatureRefs:
+        - urn:feature:artifact-instance-key
+    urn:locator:alice-file-row:
+      label: Alice target file row
+      role: row
+      accessibleFeatureRefs:
+        - urn:feature:artifact-instance-key
+    urn:locator:alice-share-row:
+      label: Confirmed outgoing share row
+      role: row
+      accessibleFeatureRefs:
+        - urn:feature:remote-recipient-instance-key
+      contextLocatorRefs:
+        - urn:locator:sharing-panel
+    urn:locator:bob-accept-share-button:
+      label: Bob accept share button
+      role: button
+      accessibleNameRef: urn:message:accept-action
+      contextLocatorRefs:
+        - urn:locator:incoming-share-row
+    urn:locator:bob-file-row:
+      label: Bob accepted file row
+      role: row
+      accessibleFeatureRefs:
+        - urn:feature:artifact-instance-key
+    urn:locator:bob-open-file-action:
+      label: Bob open file action
+      role: button
+      accessibleNameRef: urn:message:open-action
+      contextLocatorRefs:
+        - urn:locator:bob-file-row
+    urn:locator:confirm-share-button:
+      label: Confirm share button
+      role: button
+      accessibleNameRef: urn:message:confirm-share-action
+      contextLocatorRefs:
+        - urn:locator:remote-recipient-entry
+    urn:locator:file-share-action:
+      label: File share action
+      role: button
+      accessibleNameRef: urn:message:share-action
+      contextLocatorRefs:
+        - urn:locator:alice-file-row
+    urn:locator:incoming-share-row:
+      label: Incoming share row
+      role: row
+      accessibleFeatureRefs:
+        - urn:feature:artifact-instance-key
+    urn:locator:remote-recipient-entry:
+      label: Remote recipient result
+      role: option
+      accessibleFeatureRefs:
+        - urn:feature:remote-recipient-instance-key
+      contextLocatorRefs:
+        - urn:locator:sharing-panel
+    urn:locator:remote-recipient-input:
+      label: Remote recipient input
+      role: textbox
+      accessibleNameRef: urn:message:remote-recipient-input
+      contextLocatorRefs:
+        - urn:locator:sharing-panel
+    urn:locator:sharing-panel:
+      label: Sharing panel
+      role: complementary
+      accessibleNameRef: urn:message:sharing-panel
+journeyEntryIndex:
+  label: Federated sharing local journey entries
+  stateRefs:
+    - urn:composite:alice-federated-sharing
+    - urn:composite:bob-remote-share
+  id: urn:index:nextcloud-federated-sharing
+messageBundle:
+  urn:message:accept-action:
+    label: Accept action
+    namespace: nextcloud.actions
+    messageKey: actions.accept
+    defaultLocale: en
+    locales:
+      en:
+        value: Accept
+  urn:message:confirm-share-action:
+    label: Confirm share action
+    namespace: nextcloud.actions
+    messageKey: actions.confirmShare
+    defaultLocale: en
+    locales:
+      en:
+        value: Share
+  urn:message:open-action:
+    label: Open action
+    namespace: nextcloud.actions
+    messageKey: actions.open
+    defaultLocale: en
+    locales:
+      en:
+        value: Open
+  urn:message:remote-recipient-input:
+    label: Remote recipient input label
+    namespace: nextcloud.sharing
+    messageKey: sharing.remoteRecipientInput
+    defaultLocale: en
+    locales:
+      en:
+        value: Name, federated cloud ID or email address
+  urn:message:share-action:
+    label: Share action
+    namespace: nextcloud.actions
+    messageKey: actions.share
+    defaultLocale: en
+    locales:
+      en:
+        value: Share
+  urn:message:sharing-panel:
+    label: Sharing panel label
+    namespace: nextcloud.sharing
+    messageKey: sharing.panel
+    defaultLocale: en
+    locales:
+      en:
+        value: Sharing
+observationBindings:
+  urn:obs:alice-confirms-share-activation:
+    label: Activate Alice share confirmation
+    observeSurfaceRef: urn:surface:alice-confirms-share
+    observationEventRef: https://ujg.specs.openuji.org/ed/ns/observability#activation
+    locatorRefs:
+      - urn:locator:confirm-share-button
+    surfaceInstanceResolverRef: urn:resolver:artifact-instance
+  urn:obs:alice-enters-remote-bob-activation:
+    label: Activate Alice remote recipient entry
+    observeSurfaceRef: urn:surface:alice-enters-remote-bob
+    observationEventRef: https://ujg.specs.openuji.org/ed/ns/observability#activation
+    locatorRefs:
+      - urn:locator:remote-recipient-input
+  urn:obs:alice-files-ready-presence:
+    label: Observe Alice files ready
+    observeSurfaceRef: urn:surface:alice-files-ready
+    observationEventRef: https://ujg.specs.openuji.org/ed/ns/observability#presence
+    locatorRefs:
+      - urn:locator:alice-file-row
+    surfaceInstanceResolverRef: urn:resolver:artifact-instance
+  urn:obs:alice-opens-file-menu-activation:
+    label: Activate Alice share action
+    observeSurfaceRef: urn:surface:alice-opens-file-menu
+    observationEventRef: https://ujg.specs.openuji.org/ed/ns/observability#activation
+    locatorRefs:
+      - urn:locator:file-share-action
+    surfaceInstanceResolverRef: urn:resolver:artifact-instance
+  urn:obs:alice-remote-recipient-entered-presence:
+    label: Observe Alice remote recipient entered
+    observeSurfaceRef: urn:surface:alice-remote-recipient-entered
+    observationEventRef: https://ujg.specs.openuji.org/ed/ns/observability#presence
+    locatorRefs:
+      - urn:locator:remote-recipient-entry
+  urn:obs:alice-share-confirmed-presence:
+    label: Observe Alice share confirmed
+    observeSurfaceRef: urn:surface:alice-share-confirmed
+    observationEventRef: https://ujg.specs.openuji.org/ed/ns/observability#presence
+    locatorRefs:
+      - urn:locator:alice-share-row
+    surfaceInstanceResolverRef: urn:resolver:artifact-instance
+  urn:obs:alice-share-panel-open-presence:
+    label: Observe Alice share panel open
+    observeSurfaceRef: urn:surface:alice-share-panel-open
+    observationEventRef: https://ujg.specs.openuji.org/ed/ns/observability#presence
+    locatorRefs:
+      - urn:locator:sharing-panel
+  urn:obs:bob-accepts-share-activation:
+    label: Activate Bob share acceptance
+    observeSurfaceRef: urn:surface:bob-accepts-share
+    observationEventRef: https://ujg.specs.openuji.org/ed/ns/observability#activation
+    locatorRefs:
+      - urn:locator:bob-accept-share-button
+    surfaceInstanceResolverRef: urn:resolver:artifact-instance
+  urn:obs:bob-file-visible-presence:
+    label: Observe Bob file visible
+    observeSurfaceRef: urn:surface:bob-file-visible
+    observationEventRef: https://ujg.specs.openuji.org/ed/ns/observability#presence
+    locatorRefs:
+      - urn:locator:bob-file-row
+    surfaceInstanceResolverRef: urn:resolver:artifact-instance
+  urn:obs:bob-incoming-share-visible-presence:
+    label: Observe Bob incoming share
+    observeSurfaceRef: urn:surface:bob-incoming-share-visible
+    observationEventRef: https://ujg.specs.openuji.org/ed/ns/observability#presence
+    locatorRefs:
+      - urn:locator:incoming-share-row
+    surfaceInstanceResolverRef: urn:resolver:artifact-instance
+  urn:obs:bob-opens-accepted-file-activation:
+    label: Activate Bob open accepted file
+    observeSurfaceRef: urn:surface:bob-opens-accepted-file
+    observationEventRef: https://ujg.specs.openuji.org/ed/ns/observability#activation
+    locatorRefs:
+      - urn:locator:bob-open-file-action
+    surfaceInstanceResolverRef: urn:resolver:artifact-instance
+  urn:obs:bob-share-accepted-presence:
+    label: Observe Bob share accepted
+    observeSurfaceRef: urn:surface:bob-share-accepted
+    observationEventRef: https://ujg.specs.openuji.org/ed/ns/observability#presence
+    locatorRefs:
+      - urn:locator:accepted-share-row
+    surfaceInstanceResolverRef: urn:resolver:artifact-instance
+phases:
+  urn:phase:federated-access-established:
+    label: Federated access established
+    order: 2
+  urn:phase:remote-share-offered:
+    label: Remote share offered
+    order: 1
+resolvers:
+  urn:resolver:artifact-instance:
+    label: Resolve repeated artifact surface instances
+    instanceKeyFeatureRef: urn:feature:artifact-instance-key
+experienceSteps:
+  urn:step:alice-share-confirmed:
+    label: Alice outgoing share confirmed
+    surfaceRefs:
+      - urn:surface:alice-share-confirmed
+    phaseRef: urn:phase:remote-share-offered
+    order: 1
+  urn:step:bob-file-visible:
+    label: Bob accepted file visible
+    surfaceRefs:
+      - urn:surface:bob-file-visible
+    phaseRef: urn:phase:federated-access-established
+    order: 2
+  urn:step:bob-incoming-share-visible:
+    label: Bob incoming share visible
+    surfaceRefs:
+      - urn:surface:bob-incoming-share-visible
+    phaseRef: urn:phase:remote-share-offered
+    order: 2
+  urn:step:bob-share-accepted:
+    label: Bob share accepted
+    surfaceRefs:
+      - urn:surface:bob-share-accepted
+    phaseRef: urn:phase:federated-access-established
+    order: 1
+touchpoints:
+  urn:touchpoint:nextcloud-a:
+    label: Nextcloud A
+  urn:touchpoint:nextcloud-b:
+    label: Nextcloud B

--- a/packages/ujg-yaml/fixtures/auth.yaml
+++ b/packages/ujg-yaml/fixtures/auth.yaml
@@ -1,0 +1,1285 @@
+ujgTarget: ed-2026-07-13
+
+touchpoints:
+  app:
+    label: App touchpoint
+  idp:
+    label: Identity provider touchpoint
+  pod-authorization:
+    label: Pod/resource authorization touchpoint
+  authenticator-app:
+    label: Authenticator app touchpoint
+  sms-channel:
+    label: SMS channel touchpoint
+  email-provider:
+    label: Email provider touchpoint
+  platform-authenticator:
+    label: Platform authenticator touchpoint
+
+journey:
+  id: app-auth-journey
+  type: Journey
+  label: App auth journey
+  defaultEntryRef: app-auth-entry
+
+  entries:
+    app-auth-entry:
+      type: JourneyEntry
+      label: Start app auth
+      stateRef: app-sign-in-required
+
+  states:
+    app-sign-in-required:
+      type: State
+      label: Sign-in required
+      surface:
+        id: app-sign-in-required-surface
+        touchpointRef: app
+        sampleScreenRef: screens/app-sign-in-required.png
+      transitions:
+        - id: app-starts-idp-account-selection
+          type: Transition
+          label: Choose account
+          tags:
+            - primary
+            - account-selection
+            - oidc-prompt-select-account
+          to: idp-auth-flow
+        - id: app-starts-idp-auth
+          type: Transition
+          label: Start sign-in
+          tags:
+            - primary
+          to: idp-auth-flow
+          toEntryRef: idp-login-entry
+        - id: app-starts-idp-step-up-auth
+          type: Transition
+          label: Continue with step-up authentication
+          tags:
+            - primary
+            - step-up
+          to: idp-auth-flow
+          toEntryRef: idp-mfa-challenge-entry
+        - id: app-starts-identity-consent-only
+          type: Transition
+          label: Continue to identity consent
+          tags:
+            - primary
+            - identity-consent
+          to: idp-auth-flow
+          toEntryRef: idp-identity-consent-entry
+        - id: app-starts-resource-consent-only
+          type: Transition
+          label: Continue to resource consent
+          tags:
+            - primary
+            - resource-consent
+          to: idp-auth-flow
+          toEntryRef: idp-resource-consent-entry
+        - id: app-starts-existing-idp-session-auth
+          type: Transition
+          label: Existing IdP session returns to app
+          tags:
+            - shortcut
+            - existing-idp-session
+            - no-visible-idp-surface
+          to: app-auth-callback-processing
+
+    idp-auth-flow:
+      type: CompositeState
+      label: Authenticate with identity provider
+      subjourney:
+        id: idp-auth-journey
+        type: Journey
+        label: IdP auth journey
+        defaultEntryRef: idp-account-selection-entry
+
+        entries:
+          idp-login-entry:
+            type: JourneyEntry
+            label: Start at login
+            stateRef: idp-login
+          idp-account-selection-entry:
+            type: JourneyEntry
+            label: Start at account selection
+            stateRef: idp-account-selection
+          idp-mfa-challenge-entry:
+            type: JourneyEntry
+            label: Start at MFA challenge
+            stateRef: idp-mfa-challenge
+          idp-identity-consent-entry:
+            type: JourneyEntry
+            label: Start at identity consent
+            stateRef: idp-identity-consent-flow
+          idp-resource-consent-entry:
+            type: JourneyEntry
+            label: Start at resource consent
+            stateRef: idp-resource-consent-flow
+
+        states:
+          idp-account-selection:
+            type: State
+            label: Select account
+            surface:
+              id: idp-account-selection-surface
+              touchpointRef: idp
+              sampleScreenRef: screens/idp-account-selection.png
+            transitions:
+              - id: idp-account-selection-to-login
+                type: Transition
+                label: Selected account needs login
+                tags:
+                  - primary
+                to: idp-login
+              - id: idp-account-selection-to-mfa
+                type: Transition
+                label: Selected account needs MFA
+                tags:
+                  - primary
+                  - step-up
+                to: idp-mfa-challenge
+                toEntryRef: mfa-method-choice-entry
+              - id: idp-account-selection-to-identity-consent
+                type: Transition
+                label: Selected account needs identity consent
+                tags:
+                  - primary
+                  - identity-consent
+                to: idp-identity-consent-flow
+              - id: idp-account-selection-to-resource-consent
+                type: Transition
+                label: Selected account needs resource consent
+                tags:
+                  - primary
+                  - resource-consent
+                to: idp-resource-consent-flow
+              - id: idp-account-selection-to-success
+                type: Transition
+                label: Selected account already approved
+                tags:
+                  - shortcut
+                to: idp-auth-success
+              - id: idp-account-selection-cancelled
+                type: Transition
+                label: Cancel account selection
+                tags:
+                  - cancel
+                to: idp-auth-cancelled
+
+          idp-login:
+            type: State
+            label: Login
+            surface:
+              id: idp-login-surface
+              touchpointRef: idp
+              sampleScreenRef: screens/idp-login.png
+            transitions:
+              - id: idp-login-to-error
+                type: Transition
+                label: Show login error
+                tags:
+                  - validation
+                to: idp-login-error
+              - id: idp-login-to-account-selection
+                type: Transition
+                label: Choose another account
+                tags:
+                  - primary
+                  - optional-path
+                to: idp-account-selection
+              - id: idp-login-to-mfa-method-choice
+                type: Transition
+                label: Require MFA method choice
+                tags:
+                  - primary
+                  - step-up
+                to: idp-mfa-challenge
+                toEntryRef: mfa-method-choice-entry
+              - id: idp-login-to-authenticator-code
+                type: Transition
+                label: Use authenticator app code
+                tags:
+                  - primary
+                  - step-up
+                  - authenticator-app
+                to: idp-mfa-challenge
+                toEntryRef: mfa-authenticator-code-entry
+              - id: idp-login-to-sms-code
+                type: Transition
+                label: Use SMS code
+                tags:
+                  - primary
+                  - step-up
+                  - sms
+                to: idp-mfa-challenge
+                toEntryRef: mfa-sms-message-entry
+              - id: idp-login-to-email-code
+                type: Transition
+                label: Use email code
+                tags:
+                  - primary
+                  - step-up
+                  - email
+                to: idp-mfa-challenge
+                toEntryRef: mfa-email-message-entry
+              - id: idp-login-to-push-approval
+                type: Transition
+                label: Use authenticator push approval
+                tags:
+                  - primary
+                  - step-up
+                  - push
+                  - authenticator-app
+                to: idp-mfa-challenge
+                toEntryRef: mfa-push-approval-entry
+              - id: idp-login-to-security-key
+                type: Transition
+                label: Use security key or platform authenticator
+                tags:
+                  - primary
+                  - step-up
+                  - security-key
+                  - platform-authenticator
+                to: idp-mfa-challenge
+                toEntryRef: mfa-security-key-entry
+              - id: idp-login-to-identity-consent
+                type: Transition
+                label: Continue to identity consent
+                tags:
+                  - primary
+                  - identity-consent
+                to: idp-identity-consent-flow
+              - id: idp-login-to-resource-consent
+                type: Transition
+                label: Continue to resource consent
+                tags:
+                  - primary
+                  - resource-consent
+                  - shortcut
+                to: idp-resource-consent-flow
+              - id: idp-login-to-success
+                type: Transition
+                label: Complete without visible consent
+                tags:
+                  - shortcut
+                to: idp-auth-success
+              - id: idp-login-cancelled
+                type: Transition
+                label: Cancel login
+                tags:
+                  - cancel
+                to: idp-auth-cancelled
+
+          idp-login-error:
+            type: State
+            label: Login error
+            surface:
+              id: idp-login-error-surface
+              touchpointRef: idp
+              sampleScreenRef: screens/idp-login-error.png
+            transitions:
+              - id: idp-login-error-to-login
+                type: Transition
+                label: Retry login
+                tags:
+                  - validation
+                  - retry-local
+                to: idp-login
+              - id: idp-login-error-use-account-recovery
+                type: Transition
+                label: Use account recovery
+                tags:
+                  - optional-recovery
+                to: idp-account-recovery
+              - id: idp-login-error-contact-idp-support
+                type: Transition
+                label: Contact IdP support
+                tags:
+                  - optional-recovery
+                to: idp-support
+              - id: idp-login-error-to-failed
+                type: Transition
+                label: Login cannot continue
+                tags:
+                  - terminal-error
+                to: idp-auth-failed
+
+          idp-account-recovery:
+            type: State
+            label: Account recovery
+            surface:
+              id: idp-account-recovery-surface
+              touchpointRef: idp
+              sampleScreenRef: screens/idp-account-recovery.png
+            transitions:
+              - id: idp-account-recovery-to-login
+                type: Transition
+                label: Back to login
+                tags:
+                  - optional-recovery
+                to: idp-login
+              - id: idp-account-recovery-to-failed
+                type: Transition
+                label: End recovery as failed
+                tags:
+                  - terminal-error
+                to: idp-auth-failed
+
+          idp-support:
+            type: State
+            label: IdP support
+            surface:
+              id: idp-support-surface
+              touchpointRef: idp
+              sampleScreenRef: screens/idp-support.png
+            transitions:
+              - id: idp-support-to-failed
+                type: Transition
+                label: End auth from support
+                tags:
+                  - terminal-error
+                to: idp-auth-failed
+
+          idp-try-later:
+            type: State
+            label: Try again later
+            surface:
+              id: idp-try-later-surface
+              touchpointRef: idp
+              sampleScreenRef: screens/idp-try-later.png
+            transitions:
+              - id: idp-try-later-to-failed
+                type: Transition
+                label: End auth as failed
+                tags:
+                  - terminal-error
+                to: idp-auth-failed
+
+          idp-mfa-challenge:
+            type: CompositeState
+            label: MFA challenge
+            subjourney:
+              id: mfa-challenge-journey
+              type: Journey
+              label: MFA challenge journey
+              defaultEntryRef: mfa-method-choice-entry
+
+              entries:
+                mfa-method-choice-entry:
+                  type: JourneyEntry
+                  label: Start at MFA method choice
+                  stateRef: mfa-method-choice
+                mfa-authenticator-code-entry:
+                  type: JourneyEntry
+                  label: Start at authenticator code
+                  stateRef: mfa-authenticator-code
+                mfa-sms-message-entry:
+                  type: JourneyEntry
+                  label: Start at SMS message
+                  stateRef: mfa-sms-message
+                mfa-email-message-entry:
+                  type: JourneyEntry
+                  label: Start at email message
+                  stateRef: mfa-email-message
+                mfa-push-approval-entry:
+                  type: JourneyEntry
+                  label: Start at push approval
+                  stateRef: mfa-push-approval
+                mfa-security-key-entry:
+                  type: JourneyEntry
+                  label: Start at security key prompt
+                  stateRef: mfa-security-key-prompt
+                mfa-recovery-entry:
+                  type: JourneyEntry
+                  label: Start at recovery code
+                  stateRef: mfa-recovery-code
+
+              states:
+                mfa-method-choice:
+                  type: State
+                  label: Choose MFA method
+                  surface:
+                    id: mfa-method-choice-surface
+                    touchpointRef: idp
+                    sampleScreenRef: screens/mfa-method-choice.png
+                  transitions:
+                    - id: mfa-method-choice-to-authenticator-code
+                      type: Transition
+                      label: Choose authenticator app code
+                      tags:
+                        - primary
+                        - authenticator-app
+                      to: mfa-authenticator-code
+                    - id: mfa-method-choice-to-sms-message
+                      type: Transition
+                      label: Choose SMS code
+                      tags:
+                        - primary
+                        - sms
+                      to: mfa-sms-message
+                    - id: mfa-method-choice-to-email-message
+                      type: Transition
+                      label: Choose email code
+                      tags:
+                        - primary
+                        - email
+                      to: mfa-email-message
+                    - id: mfa-method-choice-to-push-approval
+                      type: Transition
+                      label: Choose push approval
+                      tags:
+                        - primary
+                        - push
+                        - authenticator-app
+                      to: mfa-push-approval
+                    - id: mfa-method-choice-to-security-key
+                      type: Transition
+                      label: Choose security key
+                      tags:
+                        - primary
+                        - security-key
+                        - platform-authenticator
+                      to: mfa-security-key-prompt
+                    - id: mfa-method-choice-to-recovery
+                      type: Transition
+                      label: Use recovery code
+                      tags:
+                        - primary
+                        - recovery-local
+                      to: mfa-recovery-code
+                    - id: mfa-method-choice-cancelled
+                      type: Transition
+                      label: Cancel MFA
+                      tags:
+                        - cancel
+                      to: mfa-cancelled
+
+                mfa-authenticator-code:
+                  type: State
+                  label: Authenticator app code
+                  surface:
+                    id: mfa-authenticator-code-surface
+                    touchpointRef: authenticator-app
+                    sampleScreenRef: screens/mfa-authenticator-code.png
+                  transitions:
+                    - id: mfa-authenticator-code-to-idp-entry
+                      type: Transition
+                      label: Enter code in IdP
+                      tags:
+                        - primary
+                        - cross-touchpoint-return
+                      to: mfa-enter-authenticator-code
+
+                mfa-enter-authenticator-code:
+                  type: State
+                  label: Enter authenticator code
+                  surface:
+                    id: mfa-enter-authenticator-code-surface
+                    touchpointRef: idp
+                    sampleScreenRef: screens/mfa-enter-authenticator-code.png
+                  transitions:
+                    - id: mfa-enter-authenticator-code-to-success
+                      type: Transition
+                      label: Code accepted
+                      tags:
+                        - primary
+                      to: mfa-success
+                    - id: mfa-enter-authenticator-code-to-error-visible
+                      type: Transition
+                      label: Code rejected
+                      tags:
+                        - validation
+                      to: mfa-error-visible
+
+                mfa-sms-message:
+                  type: State
+                  label: SMS message
+                  surface:
+                    id: mfa-sms-message-surface
+                    touchpointRef: sms-channel
+                    sampleScreenRef: screens/mfa-sms-message.png
+                  transitions:
+                    - id: mfa-sms-message-to-idp-entry
+                      type: Transition
+                      label: Enter SMS code in IdP
+                      tags:
+                        - primary
+                        - cross-touchpoint-return
+                      to: mfa-enter-sms-code
+                    - id: mfa-sms-message-unavailable
+                      type: Transition
+                      label: SMS unavailable
+                      tags:
+                        - channel-unavailable
+                      to: mfa-channel-unavailable
+
+                mfa-enter-sms-code:
+                  type: State
+                  label: Enter SMS code
+                  surface:
+                    id: mfa-enter-sms-code-surface
+                    touchpointRef: idp
+                    sampleScreenRef: screens/mfa-enter-sms-code.png
+                  transitions:
+                    - id: mfa-enter-sms-code-to-success
+                      type: Transition
+                      label: Code accepted
+                      tags:
+                        - primary
+                      to: mfa-success
+                    - id: mfa-enter-sms-code-to-error-visible
+                      type: Transition
+                      label: Code rejected
+                      tags:
+                        - validation
+                      to: mfa-error-visible
+
+                mfa-email-message:
+                  type: State
+                  label: Email message
+                  surface:
+                    id: mfa-email-message-surface
+                    touchpointRef: email-provider
+                    sampleScreenRef: screens/mfa-email-message.png
+                  transitions:
+                    - id: mfa-email-message-to-idp-entry
+                      type: Transition
+                      label: Enter email code in IdP
+                      tags:
+                        - primary
+                        - cross-touchpoint-return
+                      to: mfa-enter-email-code
+                    - id: mfa-email-message-unavailable
+                      type: Transition
+                      label: Email unavailable
+                      tags:
+                        - channel-unavailable
+                      to: mfa-channel-unavailable
+
+                mfa-enter-email-code:
+                  type: State
+                  label: Enter email code
+                  surface:
+                    id: mfa-enter-email-code-surface
+                    touchpointRef: idp
+                    sampleScreenRef: screens/mfa-enter-email-code.png
+                  transitions:
+                    - id: mfa-enter-email-code-to-success
+                      type: Transition
+                      label: Code accepted
+                      tags:
+                        - primary
+                      to: mfa-success
+                    - id: mfa-enter-email-code-to-error-visible
+                      type: Transition
+                      label: Code rejected
+                      tags:
+                        - validation
+                      to: mfa-error-visible
+
+                mfa-push-approval:
+                  type: State
+                  label: Push approval
+                  surface:
+                    id: mfa-push-approval-surface
+                    touchpointRef: authenticator-app
+                    sampleScreenRef: screens/mfa-push-approval.png
+                  transitions:
+                    - id: mfa-push-approval-to-success
+                      type: Transition
+                      label: Push approved
+                      tags:
+                        - primary
+                      to: mfa-success
+                    - id: mfa-push-approval-to-error-visible
+                      type: Transition
+                      label: Push denied or timed out
+                      tags:
+                        - validation
+                      to: mfa-error-visible
+
+                mfa-security-key-prompt:
+                  type: State
+                  label: Security key prompt
+                  surface:
+                    id: mfa-security-key-prompt-surface
+                    touchpointRef: platform-authenticator
+                    sampleScreenRef: screens/mfa-security-key-prompt.png
+                  transitions:
+                    - id: mfa-security-key-to-success
+                      type: Transition
+                      label: Security key accepted
+                      tags:
+                        - primary
+                      to: mfa-success
+                    - id: mfa-security-key-to-error-visible
+                      type: Transition
+                      label: Security key failed
+                      tags:
+                        - validation
+                      to: mfa-error-visible
+                    - id: mfa-security-key-cancelled
+                      type: Transition
+                      label: Security key cancelled
+                      tags:
+                        - cancel
+                      to: mfa-cancelled
+
+                mfa-recovery-code:
+                  type: State
+                  label: Recovery code
+                  surface:
+                    id: mfa-recovery-code-surface
+                    touchpointRef: idp
+                    sampleScreenRef: screens/mfa-recovery-code.png
+                  transitions:
+                    - id: mfa-recovery-code-to-success
+                      type: Transition
+                      label: Recovery code accepted
+                      tags:
+                        - primary
+                      to: mfa-success
+                    - id: mfa-recovery-code-to-error-visible
+                      type: Transition
+                      label: Recovery code rejected
+                      tags:
+                        - validation
+                      to: mfa-error-visible
+
+                mfa-error-visible:
+                  type: State
+                  label: MFA error
+                  surface:
+                    id: mfa-error-visible-surface
+                    touchpointRef: idp
+                    sampleScreenRef: screens/mfa-error.png
+                  transitions:
+                    - id: mfa-error-visible-to-method-choice
+                      type: Transition
+                      label: Choose another MFA method
+                      tags:
+                        - optional-recovery
+                      to: mfa-method-choice
+                    - id: mfa-error-visible-to-recovery-code
+                      type: Transition
+                      label: Use recovery code
+                      tags:
+                        - optional-recovery
+                        - recovery-local
+                      to: mfa-recovery-code
+                    - id: mfa-error-visible-to-error-exit
+                      type: Transition
+                      label: MFA cannot continue
+                      tags:
+                        - terminal-error
+                      to: mfa-error
+
+                mfa-channel-unavailable:
+                  type: State
+                  label: MFA channel unavailable
+                  surface:
+                    id: mfa-channel-unavailable-surface
+                    touchpointRef: idp
+                    sampleScreenRef: screens/mfa-channel-unavailable.png
+                  transitions:
+                    - id: mfa-channel-unavailable-to-method-choice
+                      type: Transition
+                      label: Choose another MFA method
+                      tags:
+                        - optional-recovery
+                      to: mfa-method-choice
+                    - id: mfa-channel-unavailable-to-error-exit
+                      type: Transition
+                      label: MFA cannot continue
+                      tags:
+                        - terminal-error
+                      to: mfa-error
+
+              exits:
+                mfa-success:
+                  type: JourneyExit
+                  label: MFA succeeded
+                mfa-cancelled:
+                  type: JourneyExit
+                  label: MFA cancelled
+                mfa-error:
+                  type: JourneyExit
+                  label: MFA error
+
+          idp-identity-consent-flow:
+            type: CompositeState
+            label: Identity consent
+            subjourney:
+              id: identity-consent-journey
+              type: Journey
+              label: Identity consent journey
+              defaultEntryRef: identity-consent-entry
+
+              entries:
+                identity-consent-entry:
+                  type: JourneyEntry
+                  label: Start identity consent
+                  stateRef: identity-consent
+
+              states:
+                identity-consent:
+                  type: State
+                  label: Identity consent
+                  surface:
+                    id: identity-consent-surface
+                    touchpointRef: idp
+                    sampleScreenRef: screens/identity-consent.png
+                  transitions:
+                    - id: identity-consent-allowed
+                      type: Transition
+                      label: Allow identity access
+                      tags:
+                        - primary
+                        - identity-consent
+                      to: identity-consent-success
+                    - id: identity-consent-already-granted
+                      type: Transition
+                      label: Identity consent already granted
+                      tags:
+                        - shortcut
+                        - identity-consent
+                      to: identity-consent-success
+                    - id: identity-consent-denied-transition
+                      type: Transition
+                      label: Deny identity access
+                      tags:
+                        - denied
+                        - identity-consent
+                      to: identity-consent-denied-visible
+                    - id: identity-consent-cancelled-transition
+                      type: Transition
+                      label: Cancel identity consent
+                      tags:
+                        - cancel
+                        - identity-consent
+                      to: identity-consent-cancelled
+
+                identity-consent-denied-visible:
+                  type: State
+                  label: Identity consent denied
+                  surface:
+                    id: identity-consent-denied-visible-surface
+                    touchpointRef: idp
+                    sampleScreenRef: screens/identity-consent-denied-visible.png
+                  transitions:
+                    - id: identity-consent-denied-visible-to-denied
+                      type: Transition
+                      label: Back to app
+                      tags:
+                        - denied
+                        - identity-consent
+                      to: identity-consent-denied
+
+              exits:
+                identity-consent-success:
+                  type: JourneyExit
+                  label: Identity consent succeeded
+                identity-consent-denied:
+                  type: JourneyExit
+                  label: Identity consent denied
+                identity-consent-cancelled:
+                  type: JourneyExit
+                  label: Identity consent cancelled
+
+          idp-resource-consent-flow:
+            type: CompositeState
+            label: Resource consent
+            subjourney:
+              id: resource-consent-journey
+              type: Journey
+              label: Resource consent journey
+              defaultEntryRef: resource-consent-entry
+
+              entries:
+                resource-consent-entry:
+                  type: JourneyEntry
+                  label: Start resource consent
+                  stateRef: resource-consent
+
+              states:
+                resource-consent:
+                  type: State
+                  label: Resource consent
+                  surface:
+                    id: resource-consent-surface
+                    touchpointRef: pod-authorization
+                    sampleScreenRef: screens/resource-consent.png
+                  transitions:
+                    - id: resource-consent-to-details
+                      type: Transition
+                      label: View resource access details
+                      tags:
+                        - primary
+                        - inspect
+                        - resource-consent
+                      to: resource-consent-details
+                    - id: resource-consent-allowed
+                      type: Transition
+                      label: Allow resource access
+                      tags:
+                        - primary
+                        - resource-consent
+                      to: resource-consent-success
+                    - id: resource-consent-already-granted
+                      type: Transition
+                      label: Resource consent already granted
+                      tags:
+                        - shortcut
+                        - resource-consent
+                      to: resource-consent-success
+                    - id: resource-consent-denied-transition
+                      type: Transition
+                      label: Deny resource access
+                      tags:
+                        - denied
+                        - resource-consent
+                      to: resource-consent-denied-visible
+                    - id: resource-consent-cancelled-transition
+                      type: Transition
+                      label: Cancel resource consent
+                      tags:
+                        - cancel
+                        - resource-consent
+                      to: resource-consent-cancelled
+                    - id: resource-consent-error-shown
+                      type: Transition
+                      label: Resource consent cannot continue
+                      tags:
+                        - terminal-error
+                        - resource-consent
+                      to: resource-consent-error-visible
+
+                resource-consent-details:
+                  type: State
+                  label: Resource consent details
+                  surface:
+                    id: resource-consent-details-surface
+                    touchpointRef: pod-authorization
+                    sampleScreenRef: screens/resource-consent-details.png
+                  transitions:
+                    - id: resource-consent-details-to-resource-consent
+                      type: Transition
+                      label: Back to resource consent
+                      tags:
+                        - primary
+                        - local-back
+                        - resource-consent
+                      to: resource-consent
+                    - id: resource-consent-details-allowed
+                      type: Transition
+                      label: Allow resource access from details
+                      tags:
+                        - primary
+                        - resource-consent
+                      to: resource-consent-success
+                    - id: resource-consent-details-denied
+                      type: Transition
+                      label: Deny resource access from details
+                      tags:
+                        - denied
+                        - resource-consent
+                      to: resource-consent-denied-visible
+
+                resource-consent-denied-visible:
+                  type: State
+                  label: Resource consent denied
+                  surface:
+                    id: resource-consent-denied-visible-surface
+                    touchpointRef: pod-authorization
+                    sampleScreenRef: screens/resource-consent-denied-visible.png
+                  transitions:
+                    - id: resource-consent-denied-visible-to-denied
+                      type: Transition
+                      label: Back to app
+                      tags:
+                        - denied
+                        - resource-consent
+                      to: resource-consent-denied
+
+                resource-consent-error-visible:
+                  type: State
+                  label: Resource consent error
+                  surface:
+                    id: resource-consent-error-visible-surface
+                    touchpointRef: pod-authorization
+                    sampleScreenRef: screens/resource-consent-error.png
+                  transitions:
+                    - id: resource-consent-error-visible-try-later
+                      type: Transition
+                      label: Try resource authorization later
+                      tags:
+                        - optional-recovery
+                        - resource-consent
+                      to: pod-try-later
+                    - id: resource-consent-error-visible-contact-pod-support
+                      type: Transition
+                      label: Contact Pod support
+                      tags:
+                        - optional-recovery
+                        - resource-consent
+                      to: pod-support
+                    - id: resource-consent-error-visible-to-error
+                      type: Transition
+                      label: Resource consent failed
+                      tags:
+                        - terminal-error
+                        - resource-consent
+                      to: resource-consent-error
+
+                pod-try-later:
+                  type: State
+                  label: Try Pod authorization later
+                  surface:
+                    id: pod-try-later-surface
+                    touchpointRef: pod-authorization
+                    sampleScreenRef: screens/pod-try-later.png
+                  transitions:
+                    - id: pod-try-later-to-resource-consent-error
+                      type: Transition
+                      label: End resource authorization as failed
+                      tags:
+                        - terminal-error
+                        - resource-consent
+                      to: resource-consent-error
+
+                pod-support:
+                  type: State
+                  label: Pod support
+                  surface:
+                    id: pod-support-surface
+                    touchpointRef: pod-authorization
+                    sampleScreenRef: screens/pod-support.png
+                  transitions:
+                    - id: pod-support-to-resource-consent-error
+                      type: Transition
+                      label: End resource authorization as failed
+                      tags:
+                        - terminal-error
+                        - resource-consent
+                      to: resource-consent-error
+
+              exits:
+                resource-consent-success:
+                  type: JourneyExit
+                  label: Resource consent succeeded
+                resource-consent-denied:
+                  type: JourneyExit
+                  label: Resource consent denied
+                resource-consent-cancelled:
+                  type: JourneyExit
+                  label: Resource consent cancelled
+                resource-consent-error:
+                  type: JourneyExit
+                  label: Resource consent error
+
+          idp-request-invalid:
+            type: State
+            label: Invalid request
+            surface:
+              id: idp-request-invalid-surface
+              touchpointRef: idp
+              sampleScreenRef: screens/idp-request-invalid.png
+            transitions:
+              - id: idp-request-invalid-to-failed
+                type: Transition
+                label: End as failed
+                tags:
+                  - terminal-error
+                to: idp-auth-failed
+
+          idp-provider-unavailable:
+            type: State
+            label: Provider unavailable
+            surface:
+              id: idp-provider-unavailable-surface
+              touchpointRef: idp
+              sampleScreenRef: screens/idp-provider-unavailable.png
+            transitions:
+              - id: idp-provider-unavailable-try-later
+                type: Transition
+                label: Try again later
+                tags:
+                  - optional-recovery
+                to: idp-try-later
+              - id: idp-provider-unavailable-contact-support
+                type: Transition
+                label: Contact IdP support
+                tags:
+                  - optional-recovery
+                to: idp-support
+              - id: idp-provider-unavailable-to-failed
+                type: Transition
+                label: End as failed
+                tags:
+                  - terminal-error
+                to: idp-auth-failed
+
+        exits:
+          idp-auth-success:
+            type: JourneyExit
+            label: IdP auth success
+          idp-auth-denied:
+            type: JourneyExit
+            label: IdP auth denied
+          idp-auth-cancelled:
+            type: JourneyExit
+            label: IdP auth cancelled
+          idp-auth-failed:
+            type: JourneyExit
+            label: IdP auth failed
+
+        transitions:
+          - id: idp-mfa-success-to-identity-consent
+            type: Transition
+            label: Continue to identity consent after MFA
+            tags:
+              - primary
+              - identity-consent
+            from: idp-mfa-challenge
+            fromExitRef: mfa-success
+            to: idp-identity-consent-flow
+          - id: idp-mfa-success-to-resource-consent
+            type: Transition
+            label: Continue to resource consent after MFA
+            tags:
+              - primary
+              - resource-consent
+              - shortcut
+            from: idp-mfa-challenge
+            fromExitRef: mfa-success
+            to: idp-resource-consent-flow
+          - id: idp-mfa-cancelled-to-idp-cancelled
+            type: Transition
+            label: End IdP auth as cancelled
+            tags:
+              - cancel
+            from: idp-mfa-challenge
+            fromExitRef: mfa-cancelled
+            to: idp-auth-cancelled
+          - id: idp-mfa-error-to-idp-failed
+            type: Transition
+            label: End IdP auth as failed
+            tags:
+              - terminal-error
+            from: idp-mfa-challenge
+            fromExitRef: mfa-error
+            to: idp-auth-failed
+          - id: identity-consent-success-to-resource-consent
+            type: Transition
+            label: Continue to resource consent
+            tags:
+              - primary
+              - resource-consent
+            from: idp-identity-consent-flow
+            fromExitRef: identity-consent-success
+            to: idp-resource-consent-flow
+          - id: identity-consent-denied-to-idp-denied
+            type: Transition
+            label: End IdP auth as denied
+            tags:
+              - denied
+              - outcome
+            from: idp-identity-consent-flow
+            fromExitRef: identity-consent-denied
+            to: idp-auth-denied
+          - id: identity-consent-cancelled-to-idp-cancelled
+            type: Transition
+            label: End IdP auth as cancelled
+            tags:
+              - cancel
+              - outcome
+            from: idp-identity-consent-flow
+            fromExitRef: identity-consent-cancelled
+            to: idp-auth-cancelled
+          - id: resource-consent-success-to-idp-success
+            type: Transition
+            label: Complete IdP auth after resource consent
+            tags:
+              - primary
+              - outcome
+            from: idp-resource-consent-flow
+            fromExitRef: resource-consent-success
+            to: idp-auth-success
+          - id: resource-consent-denied-to-idp-denied
+            type: Transition
+            label: End IdP auth as denied
+            tags:
+              - denied
+              - outcome
+            from: idp-resource-consent-flow
+            fromExitRef: resource-consent-denied
+            to: idp-auth-denied
+          - id: resource-consent-cancelled-to-idp-cancelled
+            type: Transition
+            label: End IdP auth as cancelled
+            tags:
+              - cancel
+              - outcome
+            from: idp-resource-consent-flow
+            fromExitRef: resource-consent-cancelled
+            to: idp-auth-cancelled
+          - id: resource-consent-error-to-idp-failed
+            type: Transition
+            label: End IdP auth as failed
+            tags:
+              - terminal-error
+              - outcome
+            from: idp-resource-consent-flow
+            fromExitRef: resource-consent-error
+            to: idp-auth-failed
+
+    app-auth-callback-processing:
+      type: State
+      label: Completing sign-in
+      surface:
+        id: app-auth-callback-processing-surface
+        touchpointRef: app
+        sampleScreenRef: screens/app-auth-callback-processing.png
+      transitions:
+        - id: app-finishes-login
+          type: Transition
+          label: Finish sign-in
+          tags:
+            - primary
+          to: app-logged-in
+        - id: app-callback-processing-fails
+          type: Transition
+          label: Callback processing failed
+          tags:
+            - terminal-error
+          to: app-login-error
+
+    app-logged-in:
+      type: State
+      label: Logged in
+      surface:
+        id: app-logged-in-surface
+        touchpointRef: app
+        sampleScreenRef: screens/app-logged-in.png
+
+    app-access-denied:
+      type: State
+      label: Access denied
+      surface:
+        id: app-access-denied-surface
+        touchpointRef: app
+        sampleScreenRef: screens/app-access-denied.png
+      transitions:
+        - id: app-access-denied-try-another-account
+          type: Transition
+          label: Try another account
+          tags:
+            - optional-recovery
+          to: idp-auth-flow
+        - id: app-access-denied-continue-without-access
+          type: Transition
+          label: Continue without access
+          tags:
+            - optional-recovery
+          to: app-limited-mode
+
+    app-login-cancelled:
+      type: State
+      label: Login cancelled
+      surface:
+        id: app-login-cancelled-surface
+        touchpointRef: app
+        sampleScreenRef: screens/app-login-cancelled.png
+      transitions:
+        - id: app-login-cancelled-resume-sign-in
+          type: Transition
+          label: Resume sign-in
+          tags:
+            - optional-recovery
+          to: idp-auth-flow
+        - id: app-login-cancelled-return-to-app
+          type: Transition
+          label: Return to app
+          tags:
+            - optional-recovery
+          to: app-unauthenticated
+
+    app-login-error:
+      type: State
+      label: Login error
+      surface:
+        id: app-login-error-surface
+        touchpointRef: app
+        sampleScreenRef: screens/app-login-error.png
+      transitions:
+        - id: app-login-error-try-again
+          type: Transition
+          label: Try again
+          tags:
+            - optional-recovery
+          to: idp-auth-flow
+        - id: app-login-error-contact-support
+          type: Transition
+          label: Contact support
+          tags:
+            - optional-recovery
+          to: app-support
+
+    app-limited-mode:
+      type: State
+      label: Limited mode
+      surface:
+        id: app-limited-mode-surface
+        touchpointRef: app
+        sampleScreenRef: screens/app-limited-mode.png
+
+    app-unauthenticated:
+      type: State
+      label: Unauthenticated app
+      surface:
+        id: app-unauthenticated-surface
+        touchpointRef: app
+        sampleScreenRef: screens/app-unauthenticated.png
+
+    app-support:
+      type: State
+      label: App support
+      surface:
+        id: app-support-surface
+        touchpointRef: app
+        sampleScreenRef: screens/app-support.png
+
+  transitions:
+    - id: app-continues-after-idp-success
+      type: Transition
+      label: Continue after IdP success
+      tags:
+        - primary
+        - outcome
+      from: idp-auth-flow
+      fromExitRef: idp-auth-success
+      to: app-auth-callback-processing
+    - id: app-continues-after-idp-denied
+      type: Transition
+      label: Continue after denied consent
+      tags:
+        - outcome
+      from: idp-auth-flow
+      fromExitRef: idp-auth-denied
+      to: app-access-denied
+    - id: app-continues-after-idp-cancelled
+      type: Transition
+      label: Continue after cancelled login
+      tags:
+        - outcome
+      from: idp-auth-flow
+      fromExitRef: idp-auth-cancelled
+      to: app-login-cancelled
+    - id: app-continues-after-idp-failed
+      type: Transition
+      label: Continue after failed login
+      tags:
+        - outcome
+      from: idp-auth-flow
+      fromExitRef: idp-auth-failed
+      to: app-login-error

--- a/packages/ujg-yaml/fixtures/complex.yaml
+++ b/packages/ujg-yaml/fixtures/complex.yaml
@@ -1,0 +1,407 @@
+ujgTarget: ed-2026-07-13
+
+touchpoints:
+  "urn:touchpoint:nextcloud-a":
+    label: "Nextcloud A"
+  "urn:touchpoint:nextcloud-b":
+    label: "Nextcloud B"
+
+actors:
+  "urn:actor:alice":
+    label: "Alice"
+  "urn:actor:bob":
+    label: "Bob"
+
+artifacts:
+  "urn:artifact:federated-share":
+    label: "Federated share for the test file"
+    sourceTouchpointRef: "urn:touchpoint:nextcloud-a"
+    targetTouchpointRefs:
+      - "urn:touchpoint:nextcloud-b"
+
+actions:
+  "urn:action:alice-confirm-share":
+    label: "Alice confirms the remote share"
+    producedArtifactRefs:
+      - "urn:artifact:federated-share"
+  "urn:action:bob-accept-share":
+    label: "Bob accepts the incoming remote share"
+    consumedArtifactRefs:
+      - "urn:artifact:federated-share"
+  "urn:action:bob-open-accepted-file":
+    label: "Bob opens the accepted file"
+    consumedArtifactRefs:
+      - "urn:artifact:federated-share"
+
+journeyEntryIndex:
+  id: "urn:index:nextcloud-federated-sharing"
+  label: "Federated sharing local journey entries"
+  stateRefs:
+    - "urn:composite:alice-federated-sharing"
+    - "urn:composite:bob-remote-share"
+
+states:
+  "urn:composite:alice-federated-sharing":
+    type: "CompositeState"
+    label: "Alice federated sharing entry"
+    subjourney:
+      id: "urn:journey:alice-federated-sharing"
+      label: "Alice shares a file with a remote recipient"
+      subjectActorRef: "urn:actor:alice"
+      defaultEntryRef: "urn:entry:alice-federated-sharing"
+      entries:
+        "urn:entry:alice-federated-sharing":
+          label: "Alice files entry"
+          stateRef: "urn:state:alice-files-ready"
+      states:
+        "urn:state:alice-files-ready":
+          label: "Alice files app is ready"
+          surface:
+            id: "urn:surface:alice-files-ready"
+            label: "Alice files list with target file"
+            touchpointRef: "urn:touchpoint:nextcloud-a"
+        "urn:state:alice-share-panel-open":
+          label: "Alice sharing panel is open"
+          surface:
+            id: "urn:surface:alice-share-panel-open"
+            label: "Alice share panel for target file"
+            touchpointRef: "urn:touchpoint:nextcloud-a"
+        "urn:state:alice-remote-recipient-entered":
+          label: "Alice entered Bob as a remote recipient"
+          surface:
+            id: "urn:surface:alice-remote-recipient-entered"
+            label: "Alice remote recipient entry"
+            touchpointRef: "urn:touchpoint:nextcloud-a"
+        "urn:state:alice-share-confirmed":
+          label: "Alice confirmed the remote share"
+          surface:
+            id: "urn:surface:alice-share-confirmed"
+            label: "Alice outgoing remote share is confirmed"
+            touchpointRef: "urn:touchpoint:nextcloud-a"
+      transitions:
+        - id: "urn:transition:alice-opens-file-menu"
+          label: "Alice opens the sharing panel"
+          from: "urn:state:alice-files-ready"
+          to: "urn:state:alice-share-panel-open"
+          surface:
+            id: "urn:surface:alice-opens-file-menu"
+            label: "Alice file share action"
+            touchpointRef: "urn:touchpoint:nextcloud-a"
+        - id: "urn:transition:alice-enters-remote-bob"
+          label: "Alice enters Bob's federated address"
+          from: "urn:state:alice-share-panel-open"
+          to: "urn:state:alice-remote-recipient-entered"
+          surface:
+            id: "urn:surface:alice-enters-remote-bob"
+            label: "Alice remote recipient input"
+            touchpointRef: "urn:touchpoint:nextcloud-a"
+        - id: "urn:transition:alice-confirms-share"
+          label: "Alice confirms the share"
+          from: "urn:state:alice-remote-recipient-entered"
+          to: "urn:state:alice-share-confirmed"
+          surface:
+            id: "urn:surface:alice-confirms-share"
+            label: "Alice confirm-share action"
+            touchpointRef: "urn:touchpoint:nextcloud-a"
+          actionRef: "urn:action:alice-confirm-share"
+  "urn:composite:bob-remote-share":
+    type: "CompositeState"
+    label: "Bob remote-share entry"
+    subjourney:
+      id: "urn:journey:bob-remote-share"
+      label: "Bob accepts an incoming remote share"
+      subjectActorRef: "urn:actor:bob"
+      defaultEntryRef: "urn:entry:bob-remote-share"
+      entries:
+        "urn:entry:bob-remote-share":
+          label: "Bob incoming share entry"
+          stateRef: "urn:state:bob-incoming-share-visible"
+      states:
+        "urn:state:bob-incoming-share-visible":
+          label: "Bob sees the pending remote share"
+          surface:
+            id: "urn:surface:bob-incoming-share-visible"
+            label: "Bob incoming remote share row"
+            touchpointRef: "urn:touchpoint:nextcloud-b"
+        "urn:state:bob-share-accepted":
+          label: "Bob accepted the remote share"
+          surface:
+            id: "urn:surface:bob-share-accepted"
+            label: "Bob accepted remote share"
+            touchpointRef: "urn:touchpoint:nextcloud-b"
+        "urn:state:bob-file-visible":
+          label: "Bob can see the shared file"
+          surface:
+            id: "urn:surface:bob-file-visible"
+            label: "Bob sees accepted file"
+            touchpointRef: "urn:touchpoint:nextcloud-b"
+      transitions:
+        - id: "urn:transition:bob-accepts-share"
+          label: "Bob accepts the incoming share"
+          from: "urn:state:bob-incoming-share-visible"
+          to: "urn:state:bob-share-accepted"
+          surface:
+            id: "urn:surface:bob-accepts-share"
+            label: "Bob accept-share action"
+            touchpointRef: "urn:touchpoint:nextcloud-b"
+          actionRef: "urn:action:bob-accept-share"
+        - id: "urn:transition:bob-opens-accepted-file"
+          label: "Bob opens the accepted shared file"
+          from: "urn:state:bob-share-accepted"
+          to: "urn:state:bob-file-visible"
+          surface:
+            id: "urn:surface:bob-opens-accepted-file"
+            label: "Bob open-file action"
+            touchpointRef: "urn:touchpoint:nextcloud-b"
+          actionRef: "urn:action:bob-open-accepted-file"
+
+messageBundle:
+  "urn:message:sharing-panel":
+    label: "Sharing panel label"
+    namespace: "nextcloud.sharing"
+    messageKey: "sharing.panel"
+    defaultLocale: "en"
+    locales:
+      en:
+        value: "Sharing"
+  "urn:message:remote-recipient-input":
+    label: "Remote recipient input label"
+    namespace: "nextcloud.sharing"
+    messageKey: "sharing.remoteRecipientInput"
+    defaultLocale: "en"
+    locales:
+      en:
+        value: "Name, federated cloud ID or email address"
+  "urn:message:share-action":
+    label: "Share action"
+    namespace: "nextcloud.actions"
+    messageKey: "actions.share"
+    defaultLocale: "en"
+    locales:
+      en:
+        value: "Share"
+  "urn:message:confirm-share-action":
+    label: "Confirm share action"
+    namespace: "nextcloud.actions"
+    messageKey: "actions.confirmShare"
+    defaultLocale: "en"
+    locales:
+      en:
+        value: "Share"
+  "urn:message:accept-action":
+    label: "Accept action"
+    namespace: "nextcloud.actions"
+    messageKey: "actions.accept"
+    defaultLocale: "en"
+    locales:
+      en:
+        value: "Accept"
+  "urn:message:open-action":
+    label: "Open action"
+    namespace: "nextcloud.actions"
+    messageKey: "actions.open"
+    defaultLocale: "en"
+    locales:
+      en:
+        value: "Open"
+
+accessible:
+  features:
+    "urn:feature:artifact-instance-key":
+      label: "Artifact instance key"
+      accessibleFeatureName: "file-id"
+      accessibleFeatureValue: "*"
+    "urn:feature:remote-recipient-instance-key":
+      label: "Remote recipient instance key"
+      accessibleFeatureName: "federated-cloud-id"
+      accessibleFeatureValue: "*"
+
+  locators:
+    "urn:locator:sharing-panel":
+      label: "Sharing panel"
+      role: "complementary"
+      accessibleNameRef: "urn:message:sharing-panel"
+    "urn:locator:alice-file-row":
+      label: "Alice target file row"
+      role: "row"
+      accessibleFeatureRefs:
+        - "urn:feature:artifact-instance-key"
+    "urn:locator:remote-recipient-entry":
+      label: "Remote recipient result"
+      role: "option"
+      accessibleFeatureRefs:
+        - "urn:feature:remote-recipient-instance-key"
+      contextLocatorRefs:
+        - "urn:locator:sharing-panel"
+    "urn:locator:alice-share-row":
+      label: "Confirmed outgoing share row"
+      role: "row"
+      accessibleFeatureRefs:
+        - "urn:feature:remote-recipient-instance-key"
+      contextLocatorRefs:
+        - "urn:locator:sharing-panel"
+    "urn:locator:incoming-share-row":
+      label: "Incoming share row"
+      role: "row"
+      accessibleFeatureRefs:
+        - "urn:feature:artifact-instance-key"
+    "urn:locator:accepted-share-row":
+      label: "Accepted share row"
+      role: "row"
+      accessibleFeatureRefs:
+        - "urn:feature:artifact-instance-key"
+    "urn:locator:bob-file-row":
+      label: "Bob accepted file row"
+      role: "row"
+      accessibleFeatureRefs:
+        - "urn:feature:artifact-instance-key"
+    "urn:locator:file-share-action":
+      label: "File share action"
+      role: "button"
+      accessibleNameRef: "urn:message:share-action"
+      contextLocatorRefs:
+        - "urn:locator:alice-file-row"
+    "urn:locator:remote-recipient-input":
+      label: "Remote recipient input"
+      role: "textbox"
+      accessibleNameRef: "urn:message:remote-recipient-input"
+      contextLocatorRefs:
+        - "urn:locator:sharing-panel"
+    "urn:locator:confirm-share-button":
+      label: "Confirm share button"
+      role: "button"
+      accessibleNameRef: "urn:message:confirm-share-action"
+      contextLocatorRefs:
+        - "urn:locator:remote-recipient-entry"
+    "urn:locator:bob-accept-share-button":
+      label: "Bob accept share button"
+      role: "button"
+      accessibleNameRef: "urn:message:accept-action"
+      contextLocatorRefs:
+        - "urn:locator:incoming-share-row"
+    "urn:locator:bob-open-file-action":
+      label: "Bob open file action"
+      role: "button"
+      accessibleNameRef: "urn:message:open-action"
+      contextLocatorRefs:
+        - "urn:locator:bob-file-row"
+resolvers:
+  "urn:resolver:artifact-instance":
+    label: "Resolve repeated artifact surface instances"
+    instanceKeyFeatureRef: "urn:feature:artifact-instance-key"
+observationBindings:
+  "urn:obs:alice-files-ready-presence":
+    label: "Observe Alice files ready"
+    observeSurfaceRef: "urn:surface:alice-files-ready"
+    observationEventRef: "https://ujg.specs.openuji.org/ed/ns/observability#presence"
+    locatorRefs:
+      - "urn:locator:alice-file-row"
+    surfaceInstanceResolverRef: "urn:resolver:artifact-instance"
+  "urn:obs:alice-share-panel-open-presence":
+    label: "Observe Alice share panel open"
+    observeSurfaceRef: "urn:surface:alice-share-panel-open"
+    observationEventRef: "https://ujg.specs.openuji.org/ed/ns/observability#presence"
+    locatorRefs:
+      - "urn:locator:sharing-panel"
+  "urn:obs:alice-remote-recipient-entered-presence":
+    label: "Observe Alice remote recipient entered"
+    observeSurfaceRef: "urn:surface:alice-remote-recipient-entered"
+    observationEventRef: "https://ujg.specs.openuji.org/ed/ns/observability#presence"
+    locatorRefs:
+      - "urn:locator:remote-recipient-entry"
+  "urn:obs:alice-share-confirmed-presence":
+    label: "Observe Alice share confirmed"
+    observeSurfaceRef: "urn:surface:alice-share-confirmed"
+    observationEventRef: "https://ujg.specs.openuji.org/ed/ns/observability#presence"
+    locatorRefs:
+      - "urn:locator:alice-share-row"
+    surfaceInstanceResolverRef: "urn:resolver:artifact-instance"
+  "urn:obs:bob-incoming-share-visible-presence":
+    label: "Observe Bob incoming share"
+    observeSurfaceRef: "urn:surface:bob-incoming-share-visible"
+    observationEventRef: "https://ujg.specs.openuji.org/ed/ns/observability#presence"
+    locatorRefs:
+      - "urn:locator:incoming-share-row"
+    surfaceInstanceResolverRef: "urn:resolver:artifact-instance"
+  "urn:obs:bob-share-accepted-presence":
+    label: "Observe Bob share accepted"
+    observeSurfaceRef: "urn:surface:bob-share-accepted"
+    observationEventRef: "https://ujg.specs.openuji.org/ed/ns/observability#presence"
+    locatorRefs:
+      - "urn:locator:accepted-share-row"
+    surfaceInstanceResolverRef: "urn:resolver:artifact-instance"
+  "urn:obs:bob-file-visible-presence":
+    label: "Observe Bob file visible"
+    observeSurfaceRef: "urn:surface:bob-file-visible"
+    observationEventRef: "https://ujg.specs.openuji.org/ed/ns/observability#presence"
+    locatorRefs:
+      - "urn:locator:bob-file-row"
+    surfaceInstanceResolverRef: "urn:resolver:artifact-instance"
+  "urn:obs:alice-opens-file-menu-activation":
+    label: "Activate Alice share action"
+    observeSurfaceRef: "urn:surface:alice-opens-file-menu"
+    observationEventRef: "https://ujg.specs.openuji.org/ed/ns/observability#activation"
+    locatorRefs:
+      - "urn:locator:file-share-action"
+    surfaceInstanceResolverRef: "urn:resolver:artifact-instance"
+  "urn:obs:alice-enters-remote-bob-activation":
+    label: "Activate Alice remote recipient entry"
+    observeSurfaceRef: "urn:surface:alice-enters-remote-bob"
+    observationEventRef: "https://ujg.specs.openuji.org/ed/ns/observability#activation"
+    locatorRefs:
+      - "urn:locator:remote-recipient-input"
+  "urn:obs:alice-confirms-share-activation":
+    label: "Activate Alice share confirmation"
+    observeSurfaceRef: "urn:surface:alice-confirms-share"
+    observationEventRef: "https://ujg.specs.openuji.org/ed/ns/observability#activation"
+    locatorRefs:
+      - "urn:locator:confirm-share-button"
+    surfaceInstanceResolverRef: "urn:resolver:artifact-instance"
+  "urn:obs:bob-accepts-share-activation":
+    label: "Activate Bob share acceptance"
+    observeSurfaceRef: "urn:surface:bob-accepts-share"
+    observationEventRef: "https://ujg.specs.openuji.org/ed/ns/observability#activation"
+    locatorRefs:
+      - "urn:locator:bob-accept-share-button"
+    surfaceInstanceResolverRef: "urn:resolver:artifact-instance"
+  "urn:obs:bob-opens-accepted-file-activation":
+    label: "Activate Bob open accepted file"
+    observeSurfaceRef: "urn:surface:bob-opens-accepted-file"
+    observationEventRef: "https://ujg.specs.openuji.org/ed/ns/observability#activation"
+    locatorRefs:
+      - "urn:locator:bob-open-file-action"
+    surfaceInstanceResolverRef: "urn:resolver:artifact-instance"
+
+phases:
+  "urn:phase:remote-share-offered":
+    label: "Remote share offered"
+    order: 1
+  "urn:phase:federated-access-established":
+    label: "Federated access established"
+    order: 2
+
+experienceSteps:
+  "urn:step:alice-share-confirmed":
+    label: "Alice outgoing share confirmed"
+    order: 1
+    surfaceRefs:
+      - "urn:surface:alice-share-confirmed"
+    phaseRef: "urn:phase:remote-share-offered"
+  "urn:step:bob-incoming-share-visible":
+    label: "Bob incoming share visible"
+    order: 2
+    surfaceRefs:
+      - "urn:surface:bob-incoming-share-visible"
+    phaseRef: "urn:phase:remote-share-offered"
+  "urn:step:bob-share-accepted":
+    label: "Bob share accepted"
+    order: 1
+    surfaceRefs:
+      - "urn:surface:bob-share-accepted"
+    phaseRef: "urn:phase:federated-access-established"
+  "urn:step:bob-file-visible":
+    label: "Bob accepted file visible"
+    order: 2
+    surfaceRefs:
+      - "urn:surface:bob-file-visible"
+    phaseRef: "urn:phase:federated-access-established"

--- a/packages/ujg-yaml/package.json
+++ b/packages/ujg-yaml/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@openuji/ujg-yaml",
+  "version": "0.0.1",
+  "type": "module",
+  "bin": {
+    "ujg-yaml": "./src/cli.js"
+  },
+  "exports": {
+    ".": "./src/index.js"
+  },
+  "files": [
+    "README.md",
+    "fixtures",
+    "scripts",
+    "src",
+    "targets",
+    "scope.md",
+    "SKILL.md"
+  ],
+  "scripts": {
+    "vocab:update": "node scripts/build-target-vocabulary.js ed-2026-07-13",
+    "vocab:check": "node scripts/build-target-vocabulary.js --check ed-2026-07-13",
+    "test": "node --test tests/*.test.js",
+    "check": "node --check src/*.js scripts/*.js && pnpm run vocab:check"
+  },
+  "dependencies": {
+    "n3": "^2.1.1",
+    "yaml": "^2.8.1"
+  }
+}

--- a/packages/ujg-yaml/scripts/build-target-vocabulary.js
+++ b/packages/ujg-yaml/scripts/build-target-vocabulary.js
@@ -1,0 +1,363 @@
+#!/usr/bin/env node
+import { createHash } from 'node:crypto';
+import { readFile, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { Parser } from 'n3';
+
+const PACKAGE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const REPO_ROOT = resolve(PACKAGE_ROOT, '../..');
+const TARGETS_DIR = resolve(PACKAGE_ROOT, 'targets');
+
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+const OWL_CLASS = 'http://www.w3.org/2002/07/owl#Class';
+const OWL_OBJECT_PROPERTY = 'http://www.w3.org/2002/07/owl#ObjectProperty';
+const OWL_DATATYPE_PROPERTY = 'http://www.w3.org/2002/07/owl#DatatypeProperty';
+const SH_PATH = 'http://www.w3.org/ns/shacl#path';
+const SH_MIN_COUNT = 'http://www.w3.org/ns/shacl#minCount';
+const SH_MAX_COUNT = 'http://www.w3.org/ns/shacl#maxCount';
+const SH_CLASS = 'http://www.w3.org/ns/shacl#class';
+const SH_DATATYPE = 'http://www.w3.org/ns/shacl#datatype';
+const SH_NODE_KIND = 'http://www.w3.org/ns/shacl#nodeKind';
+const SH_NODE = 'http://www.w3.org/ns/shacl#node';
+
+export async function buildVocabularyForTargetId(targetId, options = {}) {
+  const targetPath = resolve(TARGETS_DIR, `${targetId}.json`);
+  const target = JSON.parse(await readFile(targetPath, 'utf8'));
+  return buildVocabularyForTarget(target, options);
+}
+
+export async function buildVocabularyForTarget(target, options = {}) {
+  const repoRoot = options.repoRoot ?? REPO_ROOT;
+  const contextTerms = {};
+  const ontologyTerms = new Map();
+  const moduleQuads = new Map();
+  const sourceArtifactHashes = {};
+
+  for (const moduleName of target.contextOrder ?? Object.keys(target.modules ?? {})) {
+    const module = target.modules?.[moduleName];
+    if (!module) continue;
+
+    for (const artifact of Object.values(module.artifacts ?? {})) {
+      sourceArtifactHashes[artifact.path] = artifact.hash;
+    }
+
+    const contextArtifact = module.artifacts?.context;
+    if (contextArtifact) {
+      const contextPath = resolve(repoRoot, contextArtifact.path);
+      const contextDocument = JSON.parse(await readFile(contextPath, 'utf8'));
+      const { terms } = parseJsonLdContext(contextDocument['@context'] ?? {}, moduleName);
+      Object.assign(contextTerms, terms);
+    }
+
+    const ontologyArtifact = module.artifacts?.ontology;
+    if (ontologyArtifact) {
+      const ontologyPath = resolve(repoRoot, ontologyArtifact.path);
+      const quads = parseTurtle(await readFile(ontologyPath, 'utf8'));
+      moduleQuads.set(moduleName, quads);
+      collectOntologyTerms(quads, moduleName, ontologyTerms);
+    }
+  }
+
+  const iriToContextTerm = new Map();
+  for (const [term, definition] of Object.entries(contextTerms)) {
+    iriToContextTerm.set(definition.iri, term);
+  }
+
+  const classes = {};
+  const properties = {};
+
+  for (const term of [...ontologyTerms.values()].sort(compareOntologyTerms)) {
+    const compactName = iriToContextTerm.get(term.iri) ?? localName(term.iri);
+    if (term.kind === 'class') {
+      classes[compactName] = {
+        iri: term.iri,
+        module: term.module,
+      };
+    } else {
+      const contextTerm = contextTerms[compactName];
+      properties[compactName] = {
+        iri: term.iri,
+        module: term.module,
+        kind: term.kind,
+        reference: contextTerm?.type === '@id',
+        set: contextTerm?.container === '@set',
+      };
+      if (contextTerm?.type && contextTerm.type !== '@id') properties[compactName].type = contextTerm.type;
+    }
+  }
+
+  for (const [term, definition] of Object.entries(contextTerms).sort(([left], [right]) =>
+    left.localeCompare(right)
+  )) {
+    if (classes[term] || properties[term]) continue;
+    if (startsWithUppercase(term)) {
+      classes[term] = {
+        iri: definition.iri,
+        module: definition.module,
+        source: 'context',
+      };
+    } else {
+      properties[term] = {
+        iri: definition.iri,
+        module: definition.module,
+        kind: definition.type === '@id' ? 'object' : 'datatype',
+        reference: definition.type === '@id',
+        set: definition.container === '@set',
+      };
+      if (definition.type && definition.type !== '@id') properties[term].type = definition.type;
+    }
+  }
+
+  const iriToModule = new Map();
+  for (const value of Object.values(classes)) iriToModule.set(value.iri, value.module);
+  for (const value of Object.values(properties)) iriToModule.set(value.iri, value.module);
+
+  const moduleDependencies = {};
+  for (const [moduleName, quads] of moduleQuads) {
+    const dependencies = new Set();
+    for (const quad of quads) {
+      for (const term of [quad.subject, quad.object]) {
+        if (term.termType !== 'NamedNode') continue;
+        const dependency = iriToModule.get(term.value);
+        if (dependency && dependency !== moduleName) dependencies.add(dependency);
+      }
+    }
+    moduleDependencies[moduleName] = [...dependencies].sort();
+  }
+
+  const propertyShapes = await collectPropertyShapes(target, contextTerms, repoRoot);
+
+  return stableObject({
+    targetId: target.id,
+    generatedFrom: {
+      targetSource: target.source,
+      artifactHashes: sourceArtifactHashes,
+    },
+    contextOrder: target.contextOrder,
+    modules: Object.fromEntries(
+      Object.entries(target.modules ?? {})
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([moduleName, module]) => [
+          moduleName,
+          {
+            contextUrl: module.contextUrl,
+            dependencies: moduleDependencies[moduleName] ?? [],
+          },
+        ])
+    ),
+    classes,
+    properties,
+    propertyShapes,
+    setProperties: Object.entries(properties)
+      .filter(([, property]) => property.set)
+      .map(([term]) => term)
+      .sort(),
+    referenceProperties: Object.entries(properties)
+      .filter(([, property]) => property.reference)
+      .map(([term]) => term)
+      .sort(),
+  });
+}
+
+export function stringifyVocabulary(vocabulary) {
+  return `${JSON.stringify(stableObject(vocabulary), null, 2)}\n`;
+}
+
+async function collectPropertyShapes(target, contextTerms, repoRoot) {
+  const iriToTerm = new Map(Object.entries(contextTerms).map(([term, definition]) => [definition.iri, term]));
+  const shapes = {};
+
+  for (const [moduleName, module] of Object.entries(target.modules ?? {})) {
+    const shapeArtifact = module.artifacts?.shape;
+    if (!shapeArtifact) continue;
+    const shapePath = resolve(repoRoot, shapeArtifact.path);
+    const quads = parseTurtle(await readFile(shapePath, 'utf8'));
+    const quadsBySubject = groupQuadsBySubject(quads);
+
+    for (const quad of quads) {
+      if (quad.predicate.value !== SH_PATH || quad.object.termType !== 'NamedNode') continue;
+      const property = iriToTerm.get(quad.object.value) ?? localName(quad.object.value);
+      const shapeQuads = quadsBySubject.get(quad.subject.id) ?? [];
+      const constraint = compactShapeConstraint(shapeQuads, moduleName);
+      shapes[property] ??= [];
+      shapes[property].push(constraint);
+    }
+  }
+
+  for (const constraints of Object.values(shapes)) {
+    constraints.sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
+  }
+
+  return shapes;
+}
+
+function compactShapeConstraint(quads, moduleName) {
+  const constraint = { module: moduleName };
+  for (const quad of quads) {
+    if (quad.predicate.value === SH_MIN_COUNT) constraint.minCount = Number(quad.object.value);
+    if (quad.predicate.value === SH_MAX_COUNT) constraint.maxCount = Number(quad.object.value);
+    if (quad.predicate.value === SH_CLASS && quad.object.termType === 'NamedNode') {
+      constraint.classIri = quad.object.value;
+    }
+    if (quad.predicate.value === SH_DATATYPE && quad.object.termType === 'NamedNode') {
+      constraint.datatype = quad.object.value;
+    }
+    if (quad.predicate.value === SH_NODE_KIND && quad.object.termType === 'NamedNode') {
+      constraint.nodeKind = localName(quad.object.value);
+    }
+    if (quad.predicate.value === SH_NODE && quad.object.termType === 'NamedNode') {
+      constraint.nodeShape = quad.object.value;
+    }
+  }
+  return stableObject(constraint);
+}
+
+function parseJsonLdContext(context, moduleName) {
+  const prefixes = {};
+  const terms = {};
+
+  for (const [term, definition] of Object.entries(context)) {
+    if (term.startsWith('@')) continue;
+    if (typeof definition === 'string' && isPrefixIri(definition)) {
+      prefixes[term] = definition;
+    }
+  }
+
+  const vocab = typeof context['@vocab'] === 'string' ? context['@vocab'] : undefined;
+
+  for (const [term, definition] of Object.entries(context)) {
+    if (term.startsWith('@') || prefixes[term]) continue;
+
+    if (typeof definition === 'string') {
+      terms[term] = {
+        iri: expandIri(definition, prefixes, vocab),
+        module: moduleName,
+      };
+      continue;
+    }
+
+    if (isPlainObject(definition) && typeof definition['@id'] === 'string') {
+      terms[term] = {
+        iri: expandIri(definition['@id'], prefixes, vocab),
+        module: moduleName,
+      };
+      if (definition['@type']) {
+        terms[term].type =
+          definition['@type'] === '@id' || definition['@type'] === '@json'
+            ? definition['@type']
+            : expandIri(definition['@type'], prefixes, vocab);
+      }
+      if (definition['@container']) terms[term].container = definition['@container'];
+    }
+  }
+
+  return { prefixes, terms };
+}
+
+function collectOntologyTerms(quads, moduleName, terms) {
+  for (const quad of quads) {
+    if (quad.predicate.value !== RDF_TYPE || quad.subject.termType !== 'NamedNode') continue;
+    if (quad.object.value === OWL_CLASS) {
+      terms.set(quad.subject.value, { iri: quad.subject.value, module: moduleName, kind: 'class' });
+    }
+    if (quad.object.value === OWL_OBJECT_PROPERTY) {
+      terms.set(quad.subject.value, { iri: quad.subject.value, module: moduleName, kind: 'object' });
+    }
+    if (quad.object.value === OWL_DATATYPE_PROPERTY) {
+      terms.set(quad.subject.value, { iri: quad.subject.value, module: moduleName, kind: 'datatype' });
+    }
+  }
+}
+
+function parseTurtle(input) {
+  return new Parser().parse(input);
+}
+
+function groupQuadsBySubject(quads) {
+  const grouped = new Map();
+  for (const quad of quads) {
+    const key = quad.subject.id;
+    if (!grouped.has(key)) grouped.set(key, []);
+    grouped.get(key).push(quad);
+  }
+  return grouped;
+}
+
+function expandIri(value, prefixes, vocab) {
+  if (value.startsWith('@')) return value;
+  const compactMatch = /^([A-Za-z][\w-]*):(.*)$/.exec(value);
+  if (compactMatch && prefixes[compactMatch[1]]) {
+    return `${prefixes[compactMatch[1]]}${compactMatch[2]}`;
+  }
+  if (/^[A-Za-z][A-Za-z\d+.-]*:/.test(value)) return value;
+  if (vocab) return `${vocab}${value}`;
+  return value;
+}
+
+function localName(iri) {
+  const hashIndex = iri.lastIndexOf('#');
+  if (hashIndex >= 0) return iri.slice(hashIndex + 1);
+  const slashIndex = iri.lastIndexOf('/');
+  return slashIndex >= 0 ? iri.slice(slashIndex + 1) : iri;
+}
+
+function compareOntologyTerms(left, right) {
+  return left.iri.localeCompare(right.iri);
+}
+
+function startsWithUppercase(value) {
+  return /^[A-Z]/.test(value);
+}
+
+function isPrefixIri(value) {
+  return /^https?:\/\/.+[#/]$/.test(value) || /^[A-Za-z][\w+.-]*:\/\/.+[#/]$/.test(value);
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function stableObject(value) {
+  if (Array.isArray(value)) return value.map((item) => stableObject(item));
+  if (!isPlainObject(value)) return value;
+  return Object.fromEntries(
+    Object.entries(value)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, child]) => [key, stableObject(child)])
+  );
+}
+
+async function runCli() {
+  const args = process.argv.slice(2);
+  const check = args.includes('--check');
+  const targetIds = args.filter((arg) => arg !== '--check');
+  const selectedTargets = targetIds.length > 0 ? targetIds : ['ed-2026-07-13'];
+
+  for (const targetId of selectedTargets) {
+    const outputPath = resolve(TARGETS_DIR, `${targetId}.vocab.json`);
+    const vocabulary = await buildVocabularyForTargetId(targetId);
+    const nextContent = stringifyVocabulary(vocabulary);
+
+    if (check) {
+      const currentContent = await readFile(outputPath, 'utf8');
+      if (currentContent !== nextContent) {
+        const currentHash = createHash('sha256').update(currentContent).digest('hex');
+        const nextHash = createHash('sha256').update(nextContent).digest('hex');
+        throw new Error(
+          `${outputPath} is stale: current sha256:${currentHash}, generated sha256:${nextHash}`
+        );
+      }
+      continue;
+    }
+
+    await writeFile(outputPath, nextContent);
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runCli().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/packages/ujg-yaml/src/cli.js
+++ b/packages/ujg-yaml/src/cli.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+import { readFile, writeFile } from 'node:fs/promises';
+import {
+  compileAuthoringYaml,
+  listTargets,
+  projectCanonicalJsonLd,
+  validateCanonicalJsonLd,
+} from './index.js';
+
+const [, , command, ...args] = process.argv;
+
+try {
+  if (command === 'compile') {
+    await compileCommand(args);
+  } else if (command === 'project') {
+    await projectCommand(args);
+  } else if (command === 'validate') {
+    await validateCommand(args);
+  } else if (command === 'targets' && args[0] === 'list') {
+    for (const target of listTargets()) console.log(target);
+  } else {
+    usage();
+    process.exitCode = 1;
+  }
+} catch (error) {
+  console.error(error.message);
+  process.exitCode = 1;
+}
+
+async function compileCommand(args) {
+  const { input, output, report } = parseIoArgs(args);
+  const source = await readFile(input, 'utf8');
+  const result = await compileAuthoringYaml(source, { filePath: input });
+  if (!result.ok) exitDiagnostics(result.diagnostics);
+  const json = `${JSON.stringify(result.document, null, 2)}\n`;
+  await writeOrStdout(output, json);
+  if (report) {
+    await writeFile(
+      report,
+      `${JSON.stringify({ diagnostics: result.diagnostics, provenance: result.provenance }, null, 2)}\n`
+    );
+  }
+}
+
+async function projectCommand(args) {
+  const { input, output } = parseIoArgs(args);
+  const source = await readFile(input, 'utf8');
+  const result = await projectCanonicalJsonLd(source);
+  if (!result.ok) exitDiagnostics(result.diagnostics);
+  await writeOrStdout(output, result.yaml);
+}
+
+async function validateCommand(args) {
+  const { input } = parseIoArgs(args);
+  const source = await readFile(input, 'utf8');
+  const result = await validateCanonicalJsonLd(source);
+  for (const diagnostic of result.diagnostics ?? []) printDiagnostic(diagnostic);
+  if (!result.ok) process.exitCode = 1;
+}
+
+function parseIoArgs(args) {
+  const parsed = { input: undefined, output: undefined, report: undefined };
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '-o' || arg === '--output') {
+      parsed.output = args[++index];
+    } else if (arg === '--report') {
+      parsed.report = args[++index];
+    } else if (!parsed.input) {
+      parsed.input = arg;
+    } else {
+      throw new Error(`Unexpected argument: ${arg}`);
+    }
+  }
+  if (!parsed.input) throw new Error('Missing input file.');
+  return parsed;
+}
+
+async function writeOrStdout(output, content) {
+  if (output) {
+    await writeFile(output, content);
+  } else {
+    process.stdout.write(content);
+  }
+}
+
+function exitDiagnostics(diagnostics) {
+  for (const diagnostic of diagnostics) printDiagnostic(diagnostic);
+  process.exit(1);
+}
+
+function printDiagnostic(diagnostic) {
+  const location = [diagnostic.file, diagnostic.line, diagnostic.column].filter(Boolean).join(':');
+  const prefix = location ? `${location}: ` : '';
+  console.error(`${prefix}${diagnostic.severity ?? 'error'} ${diagnostic.code}: ${diagnostic.message}`);
+  if (diagnostic.remediation) console.error(`  ${diagnostic.remediation}`);
+}
+
+function usage() {
+  console.error(`Usage:
+  ujg-yaml compile <input.ujg.yaml> [-o output.ujg.jsonld] [--report report.json]
+  ujg-yaml project <input.ujg.jsonld> [-o output.ujg.yaml]
+  ujg-yaml validate <input.ujg.jsonld>
+  ujg-yaml targets list`);
+}

--- a/packages/ujg-yaml/src/index.js
+++ b/packages/ujg-yaml/src/index.js
@@ -1,0 +1,719 @@
+import YAML from 'yaml';
+import {
+  ACCESSIBLE_REGISTRY,
+  ALLOWED_TOP_LEVEL_KEYS,
+  EXTENSION_RULES,
+  PROPERTY_ORDER,
+  SECTION_REGISTRY,
+  STRUCTURAL_KEYS,
+} from './registry.js';
+import { diagnosticError, listTargets, loadTarget } from './targets.js';
+
+export { listTargets, loadTarget };
+
+const DOCUMENT_ID = 'urn:ujg:document';
+
+export async function compileAuthoringYaml(input, options = {}) {
+  const { value, diagnostics } = parseYaml(input, options);
+  if (diagnostics.length > 0) return { ok: false, diagnostics };
+
+  const targetId = value?.ujgTarget;
+  if (typeof targetId !== 'string' || targetId.length === 0) {
+    return failure('CONTEXT_NOT_LOCKED', 'YAML document must declare ujgTarget.');
+  }
+
+  let target;
+  try {
+    target = await loadTarget(targetId, options);
+  } catch (error) {
+    return { ok: false, diagnostics: error.diagnostics ?? [toDiagnostic(error)] };
+  }
+
+  const compiler = new Compiler(target, options);
+  try {
+    const document = compiler.compile(value);
+    return {
+      ok: true,
+      document,
+      diagnostics: compiler.diagnostics,
+      provenance: {
+        authoringFormat: 'ujg-yaml/1',
+        ujgTarget: target.id,
+        targetSource: target.source,
+        usedModules: compiler.usedModules(),
+      },
+    };
+  } catch (error) {
+    return { ok: false, diagnostics: error.diagnostics ?? [toDiagnostic(error)] };
+  }
+}
+
+export async function projectCanonicalJsonLd(input, options = {}) {
+  let document;
+  try {
+    document = typeof input === 'string' ? JSON.parse(input) : input;
+  } catch (error) {
+    return failure('INVALID_JSON', `Canonical JSON-LD is not valid JSON: ${error.message}`);
+  }
+
+  const targetId = options.targetId ?? inferTargetFromContext(document['@context']);
+  if (!targetId) {
+    return failure('CONTEXT_NOT_LOCKED', 'Cannot infer ujgTarget from JSON-LD context.');
+  }
+
+  let target;
+  try {
+    target = await loadTarget(targetId, options);
+  } catch (error) {
+    return { ok: false, diagnostics: error.diagnostics ?? [toDiagnostic(error)] };
+  }
+
+  try {
+    const authoring = projectDocument(document, target);
+    const yaml = stringifyYaml(authoring);
+    const compiled = await compileAuthoringYaml(yaml, options);
+    if (!compiled.ok) return compiled;
+
+    const original = normalizeCanonical(document, target.vocabulary);
+    const roundTrip = normalizeCanonical(compiled.document, target.vocabulary);
+    if (!normalizedNodeSetsEqual(original, roundTrip)) {
+      return failure(
+        'ROUND_TRIP_MISMATCH',
+        'compile(project(canonical)) changed the normalized node set.'
+      );
+    }
+
+    return { ok: true, authoring, yaml, diagnostics: [] };
+  } catch (error) {
+    return { ok: false, diagnostics: error.diagnostics ?? [toDiagnostic(error)] };
+  }
+}
+
+export async function validateCanonicalJsonLd(input, options = {}) {
+  let document;
+  try {
+    document = typeof input === 'string' ? JSON.parse(input) : input;
+  } catch (error) {
+    return failure('INVALID_JSON', `Canonical JSON-LD is not valid JSON: ${error.message}`);
+  }
+
+  const projected = await projectCanonicalJsonLd(document, options);
+  if (!projected.ok) return projected;
+
+  return { ok: true, diagnostics: [] };
+}
+
+class Compiler {
+  constructor(target, options) {
+    this.target = target;
+    this.vocabulary = target.vocabulary;
+    this.setProperties = new Set(this.vocabulary.setProperties ?? []);
+    this.referenceProperties = new Set(this.vocabulary.referenceProperties ?? []);
+    this.options = options;
+    this.nodes = new Map();
+    this.diagnostics = [];
+  }
+
+  compile(root) {
+    assertPlainObject(root, '$');
+    for (const key of Object.keys(root)) {
+      if (!ALLOWED_TOP_LEVEL_KEYS.has(key)) {
+        throw diagnosticError('UNKNOWN_AUTHORING_TERM', `Unknown top-level authoring section "${key}".`, {
+          path: key,
+        });
+      }
+    }
+
+    for (const [sectionName, section] of Object.entries(SECTION_REGISTRY)) {
+      if (root[sectionName] === undefined) continue;
+      if (sectionName === 'journey') {
+        this.processJourney(root[sectionName], '$.journey');
+      } else if (section.collection === 'single') {
+        this.processNode(root[sectionName], section.type, `$.${sectionName}`);
+      } else {
+        this.processKeyedSection(root[sectionName], section.type, `$.${sectionName}`);
+      }
+    }
+
+    if (root.nodes !== undefined) this.processCanonicalNodes(root.nodes, '$.nodes');
+    if (root.accessible !== undefined) this.processAccessible(root.accessible);
+
+    this.validateReferences();
+
+    const nodes = [...this.nodes.values()]
+      .map((node) => normalizeNode(node, this.setProperties))
+      .sort((left, right) => left['@id'].localeCompare(right['@id']));
+
+    const document = normalizeNode(
+      {
+        '@context': this.contextsFor(nodes),
+        '@id': root['@id'] ?? root.id ?? this.options.documentId ?? DOCUMENT_ID,
+        '@type': 'UJGDocument',
+        nodes,
+      },
+      this.setProperties
+    );
+
+    return document;
+  }
+
+  processKeyedSection(sectionValue, defaultType, path) {
+    assertPlainObject(sectionValue, path);
+    for (const [id, value] of Object.entries(sectionValue)) {
+      this.processKeyedNode(id, value, defaultType, `${path}.${id}`);
+    }
+  }
+
+  processKeyedNode(id, value, defaultType, path) {
+    return this.processNode(withKeyedIdentity(id, value, path), defaultType, path);
+  }
+
+  processCanonicalNodes(nodes, path) {
+    assertArray(nodes, path);
+    for (const [index, node] of nodes.entries()) {
+      this.processCanonicalNode(node, `${path}[${index}]`);
+    }
+  }
+
+  processCanonicalNode(value, path) {
+    assertPlainObject(value, path);
+    const id = value['@id'] ?? value.id;
+    if (typeof id !== 'string' || id.length === 0) {
+      throw diagnosticError('MISSING_ID', `Canonical node at ${path} needs id.`, { path });
+    }
+
+    const type = value['@type'] ?? value.type;
+    if (typeof type !== 'string' || type.length === 0 || !this.vocabulary.classes?.[type]) {
+      throw diagnosticError('TYPE_CONFLICT', `Unsupported UJG type "${type}" for ${id}.`, {
+        path,
+        id,
+      });
+    }
+
+    const node = { '@id': id, '@type': type };
+    for (const [key, rawValue] of Object.entries(value)) {
+      if (key === 'id' || key === '@id' || key === 'type' || key === '@type') continue;
+      if (key === '@context') {
+        throw diagnosticError(
+          'UNKNOWN_AUTHORING_TERM',
+          'Node-local @context is not supported in canonical authoring nodes.',
+          { path: `${path}.@context`, id }
+        );
+      }
+      this.assignProperty(node, key, rawValue, `${path}.${key}`);
+    }
+
+    this.addNode(node, path);
+    return node;
+  }
+
+  processAccessible(accessible) {
+    assertPlainObject(accessible, '$.accessible');
+    for (const key of Object.keys(accessible)) {
+      if (!ACCESSIBLE_REGISTRY[key]) {
+        throw diagnosticError(
+          'UNKNOWN_AUTHORING_TERM',
+          `Unknown accessible authoring section "${key}".`,
+          { path: `$.accessible.${key}` }
+        );
+      }
+      this.processKeyedSection(accessible[key], ACCESSIBLE_REGISTRY[key], `$.accessible.${key}`);
+    }
+  }
+
+  processJourney(value, path) {
+    return this.processNode(value, 'Journey', path);
+  }
+
+  processNode(value, defaultType, path, owner = undefined) {
+    assertPlainObject(value, path);
+    const id = value['@id'] ?? value.id;
+    if (typeof id !== 'string' || id.length === 0) {
+      throw diagnosticError('MISSING_ID', `Addressable authoring node at ${path} needs id.`, {
+        path,
+      });
+    }
+    const type = value['@type'] ?? value.type ?? defaultType;
+    if (!this.vocabulary.classes?.[type]) {
+      throw diagnosticError('TYPE_CONFLICT', `Unsupported UJG type "${type}" for ${id}.`, {
+        path,
+        id,
+      });
+    }
+
+    const node = { '@id': id, '@type': type };
+    const nested = {};
+
+    for (const [key, rawValue] of Object.entries(value)) {
+      if (key === 'id' || key === '@id' || key === 'type' || key === '@type') continue;
+      if (STRUCTURAL_KEYS.has(key)) {
+        nested[key] = rawValue;
+        continue;
+      }
+      this.assignProperty(node, key, rawValue, `${path}.${key}`);
+    }
+
+    this.addNode(node, path);
+
+    if (nested.subjourney !== undefined) {
+      const childJourney = this.processJourney(nested.subjourney, `${path}.subjourney`);
+      this.patchNode(id, { subjourneyId: childJourney['@id'] });
+    }
+
+    if (nested.surface !== undefined) {
+      const surface = this.processNode(
+        nested.surface,
+        'Surface',
+        `${path}.surface`,
+        { graphNodeRef: id }
+      );
+      this.patchNode(surface['@id'], { graphNodeRef: id });
+    }
+
+    if (type === 'Journey') {
+      this.processJourneyChildren(id, nested, path);
+    }
+
+    if (owner?.graphNodeRef) this.patchNode(id, { graphNodeRef: owner.graphNodeRef });
+
+    return this.nodes.get(id);
+  }
+
+  processJourneyChildren(journeyId, nested, path) {
+    const entryRefs = [];
+    const stateRefs = [];
+    const exitRefs = [];
+    const transitionRefs = [];
+    const outgoingTransitionGroupRefs = [];
+
+    if (nested.entries !== undefined) {
+      assertPlainObject(nested.entries, `${path}.entries`);
+      for (const [id, entry] of Object.entries(nested.entries)) {
+        const node = this.processKeyedNode(id, entry, 'JourneyEntry', `${path}.entries.${id}`);
+        entryRefs.push(node['@id']);
+      }
+    }
+
+    if (nested.states !== undefined) {
+      assertPlainObject(nested.states, `${path}.states`);
+      for (const [id, state] of Object.entries(nested.states)) {
+        const node = this.processKeyedNode(id, state, 'State', `${path}.states.${id}`);
+        if (node['@type'] === 'JourneyExit') {
+          exitRefs.push(node['@id']);
+        } else {
+          stateRefs.push(node['@id']);
+        }
+        for (const transition of state.transitions ?? []) {
+          const transitionNode = this.processNode(
+            { from: id, ...transition },
+            'Transition',
+            `${path}.states.${id}.transitions`
+          );
+          transitionRefs.push(transitionNode['@id']);
+        }
+      }
+    }
+
+    if (nested.exits !== undefined) {
+      assertPlainObject(nested.exits, `${path}.exits`);
+      for (const [id, exit] of Object.entries(nested.exits)) {
+        const node = this.processKeyedNode(id, exit, 'JourneyExit', `${path}.exits.${id}`);
+        exitRefs.push(node['@id']);
+      }
+    }
+
+    if (nested.transitions !== undefined) {
+      assertArray(nested.transitions, `${path}.transitions`);
+      for (const transition of nested.transitions) {
+        const node = this.processNode(transition, 'Transition', `${path}.transitions`);
+        transitionRefs.push(node['@id']);
+      }
+    }
+
+    if (nested.outgoingTransitionGroups !== undefined) {
+      assertPlainObject(nested.outgoingTransitionGroups, `${path}.outgoingTransitionGroups`);
+      for (const [id, group] of Object.entries(nested.outgoingTransitionGroups)) {
+        const node = this.processKeyedNode(
+          id,
+          group,
+          'OutgoingTransitionGroup',
+          `${path}.outgoingTransitionGroups.${id}`
+        );
+        outgoingTransitionGroupRefs.push(node['@id']);
+      }
+    }
+
+    this.patchNode(journeyId, {
+      entryRefs,
+      stateRefs,
+      transitionRefs,
+      exitRefs,
+      outgoingTransitionGroupRefs,
+    });
+  }
+
+  assignProperty(node, key, value, path) {
+    if (EXTENSION_RULES[key]) {
+      node.extensions ??= {};
+      node.extensions[EXTENSION_RULES[key]] = value;
+      return;
+    }
+
+    if (!isKnownProperty(key, this.vocabulary)) {
+      throw diagnosticError('UNKNOWN_AUTHORING_TERM', `Unknown authoring property "${key}".`, {
+        path,
+      });
+    }
+
+    const property = key === 'l10n:targetLocale' ? 'targetLocale' : key;
+    node[property] = value;
+  }
+
+  addNode(node, path) {
+    const previous = this.nodes.get(node['@id']);
+    if (previous) {
+      throw diagnosticError('DUPLICATE_ID', `Duplicate definition for ${node['@id']}.`, {
+        path,
+        id: node['@id'],
+      });
+    }
+    this.nodes.set(node['@id'], node);
+  }
+
+  patchNode(id, properties) {
+    const node = this.nodes.get(id);
+    if (!node) throw new Error(`Cannot patch unknown node ${id}`);
+    for (const [key, value] of Object.entries(properties)) {
+      if (value === undefined) continue;
+      if (this.setProperties.has(key)) {
+        node[key] = mergeSet(node[key], value);
+      } else if (node[key] === undefined || value !== undefined) {
+        node[key] = value;
+      }
+    }
+  }
+
+  validateReferences() {
+    for (const node of this.nodes.values()) {
+      for (const [property, value] of Object.entries(node)) {
+        if (!this.referenceProperties.has(property)) continue;
+        const refs = Array.isArray(value) ? value : [value];
+        for (const ref of refs) {
+          if (typeof ref !== 'string') continue;
+          if (this.nodes.has(ref)) continue;
+          if (isExternalReference(ref)) continue;
+          throw diagnosticError('UNRESOLVED_REFERENCE', `Unresolved reference ${ref}.`, {
+            id: node['@id'],
+            property,
+            reference: ref,
+          });
+        }
+      }
+    }
+  }
+
+  contextsFor(nodes) {
+    const modules = new Set(['core']);
+    for (const node of nodes) {
+      addModuleWithDependencies(modules, moduleForType(node['@type'], this.vocabulary), this.vocabulary);
+      for (const property of Object.keys(node)) {
+        addModuleWithDependencies(modules, moduleForProperty(property, this.vocabulary), this.vocabulary);
+      }
+    }
+
+    return this.target.contextOrder
+      .filter((moduleName) => modules.has(moduleName))
+      .map((moduleName) => this.vocabulary.modules?.[moduleName]?.contextUrl)
+      .filter(Boolean);
+  }
+
+  usedModules() {
+    const modules = new Set(['core']);
+    for (const node of this.nodes.values()) {
+      addModuleWithDependencies(modules, moduleForType(node['@type'], this.vocabulary), this.vocabulary);
+      for (const property of Object.keys(node)) {
+        addModuleWithDependencies(modules, moduleForProperty(property, this.vocabulary), this.vocabulary);
+      }
+    }
+    return [...modules].sort();
+  }
+}
+
+function projectDocument(document, target) {
+  assertProjectableCanonicalDocument(document, target.vocabulary);
+  const normalized = normalizeCanonical(document, target.vocabulary);
+  const authoring = { ujgTarget: target.id };
+  if (typeof normalized['@id'] === 'string') authoring.id = normalized['@id'];
+  authoring.nodes = normalized.nodes.map(projectCanonicalNode);
+  return authoring;
+}
+
+function projectCanonicalNode(node) {
+  const projected = {
+    id: node['@id'],
+    type: node['@type'],
+  };
+  for (const [key, value] of Object.entries(node)) {
+    if (key === '@id' || key === '@type') continue;
+    projected[key] = value;
+  }
+  return projected;
+}
+
+function assertProjectableCanonicalDocument(document, vocabulary) {
+  assertPlainObject(document, '$');
+  if (document['@type'] !== 'UJGDocument') {
+    throw diagnosticError(
+      'INVALID_CANONICAL_JSONLD',
+      'Canonical JSON-LD document must have @type "UJGDocument".',
+      { path: '$.@type' }
+    );
+  }
+  if (!Array.isArray(document.nodes)) {
+    throw diagnosticError('INVALID_CANONICAL_JSONLD', 'Canonical JSON-LD document needs nodes.', {
+      path: '$.nodes',
+    });
+  }
+
+  for (const key of Object.keys(document)) {
+    if (key === '@context' || key === '@id' || key === '@type' || key === 'nodes') continue;
+    throw diagnosticError(
+      'LOSSY_PROJECTION',
+      `Cannot project document-level property "${key}" without losing data.`,
+      {
+        path: `$.${key}`,
+        property: key,
+        remediation: 'Keep the document in canonical JSON-LD until this property is supported.',
+      }
+    );
+  }
+
+  for (const [index, node] of document.nodes.entries()) {
+    const path = `$.nodes[${index}]`;
+    assertPlainObject(node, path);
+    const id = node['@id'];
+    if (typeof id !== 'string' || id.length === 0) {
+      throw diagnosticError('MISSING_ID', `Canonical node at ${path} needs @id.`, { path });
+    }
+    const type = node['@type'];
+    if (typeof type !== 'string' || type.length === 0 || !vocabulary.classes?.[type]) {
+      throw diagnosticError('TYPE_CONFLICT', `Unsupported UJG type "${type}" for ${id}.`, {
+        path: `${path}.@type`,
+        id,
+      });
+    }
+    for (const key of Object.keys(node)) {
+      if (key === '@id' || key === '@type') continue;
+      if (key === '@context') {
+        throw diagnosticError(
+          'LOSSY_PROJECTION',
+          'Cannot project node-local @context without losing data.',
+          {
+            path: `${path}.@context`,
+            id,
+            property: '@context',
+            remediation: 'Use only top-level locked contexts for canonical projection.',
+          }
+        );
+      }
+      if (!isKnownCanonicalProperty(key, vocabulary)) {
+        throw diagnosticError('UNKNOWN_AUTHORING_TERM', `Unknown canonical property "${key}".`, {
+          path: `${path}.${key}`,
+          id,
+          property: key,
+        });
+      }
+    }
+  }
+}
+
+function parseYaml(input, options) {
+  const diagnostics = [];
+  const document = YAML.parseDocument(input, {
+    prettyErrors: false,
+    uniqueKeys: true,
+  });
+
+  for (const error of document.errors) {
+    diagnostics.push({
+      code: error.code === 'DUPLICATE_KEY' ? 'DUPLICATE_KEY' : 'YAML_SYNTAX',
+      severity: 'error',
+      message: error.message,
+      file: options.filePath,
+      line: error.linePos?.[0]?.line,
+      column: error.linePos?.[0]?.col,
+    });
+  }
+
+  if (diagnostics.length > 0) return { diagnostics };
+
+  return {
+    value: document.toJS({ mapAsMap: false }),
+    diagnostics,
+  };
+}
+
+function normalizeCanonical(document, vocabulary) {
+  const setProperties = new Set(vocabulary.setProperties ?? []);
+  const nodes = [...(document.nodes ?? [])]
+    .map((node) => normalizeNode(node, setProperties))
+    .sort(compareById);
+  return normalizeNode({ ...document, nodes }, setProperties);
+}
+
+function normalizedNodeSetsEqual(left, right) {
+  return JSON.stringify(left.nodes) === JSON.stringify(right.nodes);
+}
+
+function normalizeNode(node, setProperties = new Set()) {
+  const normalized = {};
+  for (const [key, value] of Object.entries(node)) {
+    if (value === undefined) continue;
+    if (Array.isArray(value)) {
+      const mapped = value.map((item) =>
+        isPlainObject(item) ? normalizeNode(item, setProperties) : item
+      );
+      normalized[key] = setProperties.has(key) ? [...new Set(mapped)].sort() : mapped;
+    } else if (isPlainObject(value)) {
+      normalized[key] = orderPlainObject(value);
+    } else {
+      normalized[key] = value;
+    }
+  }
+  return orderPlainObject(normalized);
+}
+
+function stringifyYaml(value) {
+  return YAML.stringify(value, {
+    aliasDuplicateObjects: false,
+    lineWidth: 0,
+    sortMapEntries: false,
+  });
+}
+
+function orderPlainObject(object) {
+  const result = {};
+  const entries = Object.entries(object);
+  entries.sort(([left], [right]) => propertyRank(left) - propertyRank(right) || left.localeCompare(right));
+  for (const [key, value] of entries) {
+    if (Array.isArray(value)) {
+      result[key] = value.map((item) => (isPlainObject(item) ? orderPlainObject(item) : item));
+    } else if (isPlainObject(value)) {
+      result[key] = orderPlainObject(value);
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+function propertyRank(key) {
+  const index = PROPERTY_ORDER.indexOf(key);
+  return index === -1 ? PROPERTY_ORDER.length : index;
+}
+
+function mergeSet(left, right) {
+  const values = [
+    ...(Array.isArray(left) ? left : left === undefined ? [] : [left]),
+    ...(Array.isArray(right) ? right : right === undefined ? [] : [right]),
+  ];
+  return [...new Set(values)].sort();
+}
+
+function isKnownProperty(key, vocabulary) {
+  return (
+    key === 'extensions' ||
+    key === 'type' ||
+    key === '@type' ||
+    key === 'id' ||
+    key === '@id' ||
+    Boolean(vocabulary.properties?.[key]) ||
+    key === 'l10n:targetLocale'
+  );
+}
+
+function isKnownCanonicalProperty(key, vocabulary) {
+  return key === 'extensions' || Boolean(vocabulary.properties?.[key]);
+}
+
+function moduleForType(type, vocabulary) {
+  return vocabulary.classes?.[type]?.module;
+}
+
+function moduleForProperty(property, vocabulary) {
+  if (property === 'extensions') return 'core';
+  return vocabulary.properties?.[property]?.module;
+}
+
+function addModuleWithDependencies(modules, moduleName, vocabulary) {
+  if (!moduleName || modules.has(moduleName)) return;
+  for (const dependency of vocabulary.modules?.[moduleName]?.dependencies ?? []) {
+    addModuleWithDependencies(modules, dependency, vocabulary);
+  }
+  modules.add(moduleName);
+}
+
+function inferTargetFromContext(context) {
+  const contexts = Array.isArray(context) ? context : [context];
+  if (contexts.some((item) => typeof item === 'string' && item.includes('/ed/ns/'))) {
+    return 'ed-2026-07-13';
+  }
+  return undefined;
+}
+
+function isExternalReference(ref) {
+  return ref.startsWith('_:') || /^[A-Za-z][A-Za-z\d+.-]*:/.test(ref);
+}
+
+function compareById(left, right) {
+  return left['@id'].localeCompare(right['@id']);
+}
+
+function withKeyedIdentity(id, value, path) {
+  assertPlainObject(value, path);
+  for (const property of ['id', '@id']) {
+    const explicitId = value[property];
+    if (explicitId === undefined) continue;
+    if (explicitId !== id) {
+      throw diagnosticError(
+        'ID_CONFLICT',
+        `Keyed node identity "${explicitId}" does not match map key "${id}".`,
+        {
+          path: `${path}.${property}`,
+          id,
+          property,
+          remediation: 'Remove the redundant id field, or make it match the map key.',
+        }
+      );
+    }
+  }
+  return { ...value, id };
+}
+
+function assertPlainObject(value, path) {
+  if (!isPlainObject(value)) {
+    throw diagnosticError('UNKNOWN_AUTHORING_TERM', `${path} must be a mapping.`, { path });
+  }
+}
+
+function assertArray(value, path) {
+  if (!Array.isArray(value)) {
+    throw diagnosticError('UNKNOWN_AUTHORING_TERM', `${path} must be a sequence.`, { path });
+  }
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function failure(code, message, extra = {}) {
+  return { ok: false, diagnostics: [{ code, severity: 'error', message, ...extra }] };
+}
+
+function toDiagnostic(error) {
+  return {
+    code: 'INTERNAL_ERROR',
+    severity: 'error',
+    message: error.message,
+  };
+}

--- a/packages/ujg-yaml/src/registry.js
+++ b/packages/ujg-yaml/src/registry.js
@@ -1,0 +1,212 @@
+export const SECTION_REGISTRY = {
+  touchpoints: { type: 'Touchpoint', collection: 'map' },
+  actors: { type: 'Actor', collection: 'map' },
+  artifacts: { type: 'DistributedArtifact', collection: 'map' },
+  actions: { type: 'Action', collection: 'map' },
+  states: { type: 'State', collection: 'map' },
+  journeyEntryIndex: { type: 'JourneyEntryIndex', collection: 'single' },
+  messageBundle: { type: 'MessageBundle', collection: 'map' },
+  resolvers: { type: 'SurfaceInstanceResolver', collection: 'map' },
+  observationBindings: { type: 'ObservationBinding', collection: 'map' },
+  phases: { type: 'Phase', collection: 'map' },
+  experienceSteps: { type: 'ExperienceStep', collection: 'map' },
+  journey: { type: 'Journey', collection: 'legacy-single' },
+};
+
+export const ACCESSIBLE_REGISTRY = {
+  features: 'AccessibleFeature',
+  relations: 'AccessibleRelation',
+  locators: 'AccessibleLocator',
+};
+
+export const TYPE_TO_SECTION = {
+  Touchpoint: 'touchpoints',
+  Actor: 'actors',
+  Artifact: 'artifacts',
+  DistributedArtifact: 'artifacts',
+  Action: 'actions',
+  JourneyEntryIndex: 'journeyEntryIndex',
+  State: 'states',
+  CompositeState: 'states',
+  MessageBundle: 'messageBundle',
+  SurfaceInstanceResolver: 'resolvers',
+  ObservationBinding: 'observationBindings',
+  Phase: 'phases',
+  ExperienceStep: 'experienceSteps',
+};
+
+export const ACCESSIBLE_TYPE_TO_SECTION = {
+  AccessibleFeature: 'features',
+  AccessibleRelation: 'relations',
+  AccessibleLocator: 'locators',
+  CustomLocator: 'locators',
+};
+
+export const EXTENSION_RULES = {
+  sampleScreenRef: 'https://openuji.org/ujg-yaml/extensions#sampleScreenRef',
+};
+
+export const STRUCTURAL_KEYS = new Set([
+  'entries',
+  'states',
+  'transitions',
+  'exits',
+  'outgoingTransitionGroups',
+  'outgoingTransitions',
+  'subjourney',
+  'surface',
+]);
+
+export const ALLOWED_TOP_LEVEL_KEYS = new Set([
+  'ujgTarget',
+  'id',
+  '@id',
+  'nodes',
+  ...Object.keys(SECTION_REGISTRY),
+  'accessible',
+]);
+
+export const PROPERTY_ORDER = [
+  '@id',
+  '@type',
+  '@context',
+  'imports',
+  'nodes',
+  'label',
+  'tags',
+  'defaultEntryRef',
+  'entryRefs',
+  'stateRef',
+  'stateRefs',
+  'transitionRefs',
+  'exitRefs',
+  'outgoingTransitionGroupRefs',
+  'from',
+  'to',
+  'fromExitRef',
+  'toEntryRef',
+  'toCurrentState',
+  'subjourneyId',
+  'outgoingTransitionRefs',
+  'subjectActorRef',
+  'graphNodeRef',
+  'touchpointRef',
+  'surfaceRef',
+  'surfaceRefs',
+  'phaseRef',
+  'order',
+  'channel',
+  'origin',
+  'actionRef',
+  'producedArtifactRefs',
+  'consumedArtifactRefs',
+  'sourceTouchpointRef',
+  'targetTouchpointRefs',
+  'namespace',
+  'messageKey',
+  'defaultLocale',
+  'fallbackLocales',
+  'rtl',
+  'locales',
+  'targetLocale',
+  'observeSurfaceRef',
+  'observationEventRef',
+  'locatorRefs',
+  'surfaceInstanceResolverRef',
+  'instanceKeyFeatureRef',
+  'role',
+  'accessibleNameRef',
+  'accessibleDescriptionRef',
+  'accessibleFeatureRefs',
+  'accessibleRelationRefs',
+  'contextLocatorRefs',
+  'accessibleFeatureName',
+  'accessibleFeatureValue',
+  'accessibleRelationType',
+  'targetLocatorRef',
+  'conditionRef',
+  'conditionTransitionRefs',
+  'routeRef',
+  'fallbackNodeRef',
+  'routeName',
+  'path',
+  'deepLink',
+  'guards',
+  'params',
+  'executionId',
+  'previousId',
+  'surfaceInstanceRef',
+  'payload',
+  'mappedJourneyRef',
+  'mappedRuntimeRef',
+  'mappedStepRef',
+  'mappedEventRef',
+  'observedAffordanceEventRef',
+  'mappedStateRef',
+  'explainedByTransitionRef',
+  'experienceRefs',
+  'severity',
+  'description',
+  'extensions',
+];
+
+const SYNTHESIZED_CANONICAL_PROPERTIES = [
+  'subjourneyId',
+  'entryRefs',
+  'stateRefs',
+  'transitionRefs',
+  'exitRefs',
+  'outgoingTransitionGroupRefs',
+  'graphNodeRef',
+  'from',
+];
+
+const EXTENSION_NAMESPACE = 'https://openuji.org/ujg-yaml/extensions#';
+
+export function projectionRegistryDiagnostics(vocabulary) {
+  const diagnostics = [];
+
+  for (const [sectionName, section] of Object.entries(SECTION_REGISTRY)) {
+    if (!vocabulary.classes?.[section.type]) {
+      diagnostics.push(`Section "${sectionName}" references missing class "${section.type}".`);
+    }
+  }
+
+  for (const [type, sectionName] of Object.entries(TYPE_TO_SECTION)) {
+    if (!vocabulary.classes?.[type]) {
+      diagnostics.push(`Projection type "${type}" references a missing target class.`);
+    }
+    if (!SECTION_REGISTRY[sectionName]) {
+      diagnostics.push(`Projection type "${type}" maps to unknown section "${sectionName}".`);
+    }
+  }
+
+  for (const [sectionName, type] of Object.entries(ACCESSIBLE_REGISTRY)) {
+    if (!vocabulary.classes?.[type]) {
+      diagnostics.push(`Accessible section "${sectionName}" references missing class "${type}".`);
+    }
+  }
+
+  for (const [type, sectionName] of Object.entries(ACCESSIBLE_TYPE_TO_SECTION)) {
+    if (!vocabulary.classes?.[type]) {
+      diagnostics.push(`Accessible projection type "${type}" references a missing target class.`);
+    }
+    if (!ACCESSIBLE_REGISTRY[sectionName]) {
+      diagnostics.push(`Accessible projection type "${type}" maps to unknown section "${sectionName}".`);
+    }
+  }
+
+  for (const property of SYNTHESIZED_CANONICAL_PROPERTIES) {
+    if (!vocabulary.properties?.[property]) {
+      diagnostics.push(`Structural lifting synthesizes missing property "${property}".`);
+    }
+  }
+
+  for (const [property, iri] of Object.entries(EXTENSION_RULES)) {
+    if (!iri.startsWith(EXTENSION_NAMESPACE)) {
+      diagnostics.push(`Extension "${property}" must stay under ${EXTENSION_NAMESPACE}.`);
+    }
+  }
+
+  return diagnostics;
+}

--- a/packages/ujg-yaml/src/targets.js
+++ b/packages/ujg-yaml/src/targets.js
@@ -1,0 +1,174 @@
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { projectionRegistryDiagnostics } from './registry.js';
+
+const PACKAGE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const REPO_ROOT = resolve(PACKAGE_ROOT, '../..');
+
+const TARGET_FILES = {
+  'ed-2026-07-13': resolve(PACKAGE_ROOT, 'targets/ed-2026-07-13.json'),
+};
+
+const TARGET_VOCABULARY_FILES = {
+  'ed-2026-07-13': resolve(PACKAGE_ROOT, 'targets/ed-2026-07-13.vocab.json'),
+};
+
+export function listTargets() {
+  return Object.keys(TARGET_FILES).sort();
+}
+
+export async function loadTarget(targetId, options = {}) {
+  const path = TARGET_FILES[targetId];
+  if (!path) {
+    throw diagnosticError('CONTEXT_NOT_LOCKED', `Unknown UJG target "${targetId}".`, {
+      targetId,
+      remediation: `Use one of: ${listTargets().join(', ')}`,
+    });
+  }
+
+  const target = JSON.parse(await readFile(path, 'utf8'));
+  target.vocabulary = await loadTargetVocabulary(targetId);
+  if (options.verifyArtifacts !== false) {
+    await verifyTargetArtifacts(target);
+    verifyTargetVocabulary(target);
+    verifyProjectionRegistry(target);
+  }
+  return target;
+}
+
+async function loadTargetVocabulary(targetId) {
+  const path = TARGET_VOCABULARY_FILES[targetId];
+  if (!path) {
+    throw diagnosticError('CONTEXT_NOT_LOCKED', `Missing vocabulary lock for target "${targetId}".`, {
+      targetId,
+      remediation: 'Generate the target vocabulary before compiling.',
+    });
+  }
+
+  try {
+    return JSON.parse(await readFile(path, 'utf8'));
+  } catch (error) {
+    throw diagnosticError('CONTEXT_NOT_LOCKED', `Cannot load vocabulary lock for target "${targetId}".`, {
+      targetId,
+      cause: error.message,
+      remediation: 'Run pnpm --filter @openuji/ujg-yaml run vocab:update.',
+    });
+  }
+}
+
+export async function verifyTargetArtifacts(target) {
+  const mismatches = [];
+
+  for (const module of Object.values(target.modules ?? {})) {
+    for (const artifact of Object.values(module.artifacts ?? {})) {
+      const absolutePath = resolve(REPO_ROOT, artifact.path);
+      const content = await readFile(absolutePath);
+      const actualHash = `sha256:${createHash('sha256').update(content).digest('hex')}`;
+      if (actualHash !== artifact.hash) {
+        mismatches.push(`${artifact.path}: expected ${artifact.hash}, got ${actualHash}`);
+      }
+    }
+  }
+
+  if (mismatches.length > 0) {
+    throw diagnosticError(
+      'CONTEXT_NOT_LOCKED',
+      `Target "${target.id}" artifact lock is stale.`,
+      {
+        targetId: target.id,
+        details: mismatches,
+        remediation: 'Regenerate the dated ED target lock before compiling.',
+      }
+    );
+  }
+}
+
+function verifyTargetVocabulary(target) {
+  const mismatches = [];
+  const vocabulary = target.vocabulary;
+
+  if (vocabulary?.targetId !== target.id) {
+    mismatches.push(`targetId: expected ${target.id}, got ${vocabulary?.targetId ?? '<missing>'}`);
+  }
+
+  const lockedHashes = collectArtifactHashes(target);
+  const vocabularyHashes = vocabulary?.generatedFrom?.artifactHashes ?? {};
+  for (const [artifactPath, hash] of Object.entries(lockedHashes)) {
+    if (vocabularyHashes[artifactPath] !== hash) {
+      mismatches.push(
+        `${artifactPath}: target lock has ${hash}, vocabulary has ${
+          vocabularyHashes[artifactPath] ?? '<missing>'
+        }`
+      );
+    }
+  }
+
+  const targetContextOrder = JSON.stringify(target.contextOrder ?? []);
+  const vocabularyContextOrder = JSON.stringify(vocabulary?.contextOrder ?? []);
+  if (targetContextOrder !== vocabularyContextOrder) {
+    mismatches.push('contextOrder differs between target lock and vocabulary lock.');
+  }
+
+  for (const [moduleName, module] of Object.entries(target.modules ?? {})) {
+    const vocabularyContextUrl = vocabulary?.modules?.[moduleName]?.contextUrl;
+    if (vocabularyContextUrl !== module.contextUrl) {
+      mismatches.push(
+        `${moduleName}.contextUrl: expected ${module.contextUrl}, got ${
+          vocabularyContextUrl ?? '<missing>'
+        }`
+      );
+    }
+  }
+
+  if (mismatches.length > 0) {
+    throw diagnosticError(
+      'CONTEXT_NOT_LOCKED',
+      `Target "${target.id}" vocabulary lock is stale.`,
+      {
+        targetId: target.id,
+        details: mismatches,
+        remediation: 'Run pnpm --filter @openuji/ujg-yaml run vocab:update.',
+      }
+    );
+  }
+}
+
+function verifyProjectionRegistry(target) {
+  const diagnostics = projectionRegistryDiagnostics(target.vocabulary);
+  if (diagnostics.length > 0) {
+    throw diagnosticError(
+      'CONTEXT_NOT_LOCKED',
+      `Projection registry does not match target "${target.id}" vocabulary.`,
+      {
+        targetId: target.id,
+        details: diagnostics,
+        remediation: 'Update the projection registry or regenerate the target vocabulary.',
+      }
+    );
+  }
+}
+
+function collectArtifactHashes(target) {
+  const hashes = {};
+  for (const module of Object.values(target.modules ?? {})) {
+    for (const artifact of Object.values(module.artifacts ?? {})) {
+      hashes[artifact.path] = artifact.hash;
+    }
+  }
+  return hashes;
+}
+
+export function diagnosticError(code, message, extra = {}) {
+  const error = new Error(message);
+  error.diagnostics = [
+    {
+      code,
+      severity: 'error',
+      message,
+      ...extra,
+    },
+  ];
+  return error;
+}

--- a/packages/ujg-yaml/targets/ed-2026-07-13.json
+++ b/packages/ujg-yaml/targets/ed-2026-07-13.json
@@ -1,0 +1,302 @@
+{
+  "id": "ed-2026-07-13",
+  "kind": "ed",
+  "label": "Editor's Draft 2026-07-13",
+  "publicUrl": "https://ujg.specs.openuji.org/ed",
+  "source": {
+    "headCommit": "e795559ebea8a9f57e7d6d212ccb9fdd11e825d4",
+    "headDate": "2026-07-13T13:00:39+02:00",
+    "headSubject": "Merge pull request #15 from openuji/feature/surface-core",
+    "edContentCommit": "a6a73ca56c25b48457c620af158acc6f68ac1f09",
+    "edContentDate": "2026-07-13T12:52:11+02:00"
+  },
+  "contextOrder": [
+    "core",
+    "graph",
+    "surface",
+    "runtime",
+    "mapping",
+    "action",
+    "artifact",
+    "distributedJourney",
+    "condition",
+    "routing",
+    "designSystem",
+    "l10n",
+    "observability",
+    "experienceAnnotation",
+    "stateData"
+  ],
+  "modules": {
+    "core": {
+      "moduleId": "core",
+      "contextUrl": "https://ujg.specs.openuji.org/ed/ns/core.context.jsonld",
+      "artifacts": {
+        "context": {
+          "path": "specs/ed/core/core.context.jsonld",
+          "hash": "sha256:c9c560f264ce95a506ed91802e749c7d417ed34728351840aebfae40c7733e3b"
+        },
+        "shape": {
+          "path": "specs/ed/core/core.shape.ttl",
+          "hash": "sha256:7dccb70ce37bc20a2c4687d9407db0ef4e64f4c207686fa9d22251bb03376611"
+        },
+        "ontology": {
+          "path": "specs/ed/core/core.ttl",
+          "hash": "sha256:0d600641ac1b4fbe5c30a9a154945b0b91488ca23f741fc3355e4f02a7a7f686"
+        }
+      }
+    },
+    "graph": {
+      "moduleId": "graph",
+      "contextUrl": "https://ujg.specs.openuji.org/ed/ns/graph.context.jsonld",
+      "artifacts": {
+        "context": {
+          "path": "specs/ed/graph/graph.context.jsonld",
+          "hash": "sha256:c4a7198fa4ef6d7e9e835e82dd7f5ca3b8e7f565dad5833d157625c0dfb8a0c4"
+        },
+        "shape": {
+          "path": "specs/ed/graph/graph.shape.ttl",
+          "hash": "sha256:c4354a238747e8c9c53d57c320f7a17292d1814a2ff48f1cf31bc5884b0222ed"
+        },
+        "ontology": {
+          "path": "specs/ed/graph/graph.ttl",
+          "hash": "sha256:9d5d9166ce3eaef4a96c043af9463e96fb12edf92937bb1633a6c391ab00e655"
+        }
+      }
+    },
+    "surface": {
+      "moduleId": "surface",
+      "contextUrl": "https://ujg.specs.openuji.org/ed/ns/surface.context.jsonld",
+      "artifacts": {
+        "context": {
+          "path": "specs/ed/surface/surface.context.jsonld",
+          "hash": "sha256:84e2964c55d18c0242dcafb974f2a2c52258c964be3671e011bdb53dd88d7fd4"
+        },
+        "shape": {
+          "path": "specs/ed/surface/surface.shape.ttl",
+          "hash": "sha256:60582dff0640d37f80e081e0b3eb023602821e2a8b0a378acacd396b06917ca9"
+        },
+        "ontology": {
+          "path": "specs/ed/surface/surface.ttl",
+          "hash": "sha256:ab8849676f0e378f2a7dfe8b34aee83ace6949799b93e675510f6860293bd28f"
+        }
+      }
+    },
+    "action": {
+      "moduleId": "modules/action",
+      "contextUrl": "https://ujg.specs.openuji.org/ed/ns/action.context.jsonld",
+      "artifacts": {
+        "context": {
+          "path": "specs/ed/modules/action/action.context.jsonld",
+          "hash": "sha256:daf8a5ea6cf3602d980ec62648d7e51d1fc8147551f826f787b658dd7a2145b4"
+        },
+        "shape": {
+          "path": "specs/ed/modules/action/action.shape.ttl",
+          "hash": "sha256:54f5f0f8b2b58386f0ecb196620fdac2c8b98360bdf43194bc8c56ae1e19021d"
+        },
+        "ontology": {
+          "path": "specs/ed/modules/action/action.ttl",
+          "hash": "sha256:be71cefcb4044d9f6ac82ec30620b5dd28bd55dae9d808802006fb03b4291c0a"
+        }
+      }
+    },
+    "artifact": {
+      "moduleId": "modules/artifact",
+      "contextUrl": "https://ujg.specs.openuji.org/ed/ns/artifact.context.jsonld",
+      "artifacts": {
+        "context": {
+          "path": "specs/ed/modules/artifact/artifact.context.jsonld",
+          "hash": "sha256:dcdbc3f77c9c4bd23f22a3b865e412705b831bca0f3f346144fc436b5544f09a"
+        },
+        "shape": {
+          "path": "specs/ed/modules/artifact/artifact.shape.ttl",
+          "hash": "sha256:927373c5a01af37d44f06f776695102d575cf17c883dff2ebeb470aefecdc0ee"
+        },
+        "ontology": {
+          "path": "specs/ed/modules/artifact/artifact.ttl",
+          "hash": "sha256:adc9d6a74bad67d7ba44b75a47fa857df58f950afcebc4e4b4a8698c35e9d581"
+        }
+      }
+    },
+    "distributedJourney": {
+      "moduleId": "modules/distributed-journey",
+      "contextUrl": "https://ujg.specs.openuji.org/ed/ns/distributed-journey.context.jsonld",
+      "artifacts": {
+        "context": {
+          "path": "specs/ed/modules/distributed-journey/distributed-journey.context.jsonld",
+          "hash": "sha256:406e807bca61bb57e5ffc484a196ee06ff8f1ee39e925d11668c4b619c0b722a"
+        },
+        "shape": {
+          "path": "specs/ed/modules/distributed-journey/distributed-journey.shape.ttl",
+          "hash": "sha256:dcb4b6cbeca0fc337ed063af52541c96587c14d4dae2bb2dd0cc3d1b5389066b"
+        },
+        "ontology": {
+          "path": "specs/ed/modules/distributed-journey/distributed-journey.ttl",
+          "hash": "sha256:79275d603cd6739c6f64f5ed2e2c9c5f8949621940d0b8129a9fef4e84e0c798"
+        }
+      }
+    },
+    "l10n": {
+      "moduleId": "modules/l10n",
+      "contextUrl": "https://ujg.specs.openuji.org/ed/ns/l10n.context.jsonld",
+      "artifacts": {
+        "context": {
+          "path": "specs/ed/modules/l10n/l10n.context.jsonld",
+          "hash": "sha256:c91b83268f1277fc51e3ce1dbd74d909ce1af6cad5237acb1e3bd8b8f9b608d2"
+        },
+        "shape": {
+          "path": "specs/ed/modules/l10n/l10n.shape.ttl",
+          "hash": "sha256:a32504d280e43c7f4567d18c709f8a96da3f7834acecff862f0e3c617a445eba"
+        },
+        "ontology": {
+          "path": "specs/ed/modules/l10n/l10n.ttl",
+          "hash": "sha256:289c3eb4a4791e8f6961fe2c179e9735c20767c22055522e8b81800098aede9c"
+        }
+      }
+    },
+    "observability": {
+      "moduleId": "modules/observability",
+      "contextUrl": "https://ujg.specs.openuji.org/ed/ns/observability.context.jsonld",
+      "artifacts": {
+        "context": {
+          "path": "specs/ed/modules/observability/observability.context.jsonld",
+          "hash": "sha256:10c123e8057dd455b492a60df8ba56369cc6782c4232856cd14426fc231a546b"
+        },
+        "shape": {
+          "path": "specs/ed/modules/observability/observability.shape.ttl",
+          "hash": "sha256:3d5eb3b941e41fa8670318a74b673b6e9855614350a5b1f6fc30a20c7e98643f"
+        },
+        "ontology": {
+          "path": "specs/ed/modules/observability/observability.ttl",
+          "hash": "sha256:51751761af286066f747d208cc35a55a5c37a2ce356097c314db0584e96219ff"
+        }
+      }
+    },
+    "runtime": {
+      "moduleId": "runtime",
+      "contextUrl": "https://ujg.specs.openuji.org/ed/ns/runtime.context.jsonld",
+      "artifacts": {
+        "context": {
+          "path": "specs/ed/runtime/runtime.context.jsonld",
+          "hash": "sha256:4e52855fad3cf4722dc00d555520a445cbb240c655117e2532b62f72868ea438"
+        },
+        "shape": {
+          "path": "specs/ed/runtime/runtime.shape.ttl",
+          "hash": "sha256:88cfea86d2e43ab13f708f29c2deed3fd13241fe7875d1b79d254245891ab2e9"
+        },
+        "ontology": {
+          "path": "specs/ed/runtime/runtime.ttl",
+          "hash": "sha256:e3cf150e9c8f7e365afdc6a3d7eeb80d93d17ab2f1c4f589791a0144017a4992"
+        }
+      }
+    },
+    "mapping": {
+      "moduleId": "mapping",
+      "contextUrl": "https://ujg.specs.openuji.org/ed/ns/mapping.context.jsonld",
+      "artifacts": {
+        "context": {
+          "path": "specs/ed/mapping/mapping.context.jsonld",
+          "hash": "sha256:aed6286a0b0a9da31b1e2d4b71870c6c2bd80f02c54d68c592561f2014ad09a3"
+        },
+        "shape": {
+          "path": "specs/ed/mapping/mapping.shape.ttl",
+          "hash": "sha256:c7f2b3e605b13901a8aff9613c7a872f057230717e669099813b3aafce3c92ee"
+        },
+        "ontology": {
+          "path": "specs/ed/mapping/mapping.ttl",
+          "hash": "sha256:b03175d4eef29870049a1f50b64b8a4dbca7504e05a154d2374eaae1ea55ea8c"
+        }
+      }
+    },
+    "condition": {
+      "moduleId": "modules/condition",
+      "contextUrl": "https://ujg.specs.openuji.org/ed/ns/condition.context.jsonld",
+      "artifacts": {
+        "context": {
+          "path": "specs/ed/modules/condition/condition.context.jsonld",
+          "hash": "sha256:db219d5cdcef0231575307c6cf31ecc5b59d2e49614e7dede652a9e481d4d62c"
+        },
+        "shape": {
+          "path": "specs/ed/modules/condition/condition.shape.ttl",
+          "hash": "sha256:d5437cbc5e6d3bf9ed9d049bc8165574a791f62f9c5f36d7e11c0001d4a387cf"
+        },
+        "ontology": {
+          "path": "specs/ed/modules/condition/condition.ttl",
+          "hash": "sha256:3931d479f356643821498435c5694a77ac0aadeea72978e62521ba6b29c72bb8"
+        }
+      }
+    },
+    "routing": {
+      "moduleId": "modules/routing",
+      "contextUrl": "https://ujg.specs.openuji.org/ed/ns/routing.context.jsonld",
+      "artifacts": {
+        "context": {
+          "path": "specs/ed/modules/routing/routing.context.jsonld",
+          "hash": "sha256:e3db2488bdae5036c32dd9a0159c826ae9bd1024832a883b7c6175b7fd2619f8"
+        },
+        "shape": {
+          "path": "specs/ed/modules/routing/routing.shape.ttl",
+          "hash": "sha256:70d0a466e075d0aed933082acc5473773bc471099a18272a1bfc4570dca1ed40"
+        },
+        "ontology": {
+          "path": "specs/ed/modules/routing/routing.ttl",
+          "hash": "sha256:3d3cefec8dee3a0a9a6776db624ab5e582e28da09395ca0f621f92348c2fcb8c"
+        }
+      }
+    },
+    "designSystem": {
+      "moduleId": "modules/design-system",
+      "contextUrl": "https://ujg.specs.openuji.org/ed/ns/design-system.context.jsonld",
+      "artifacts": {
+        "context": {
+          "path": "specs/ed/modules/design-system/design-system.context.jsonld",
+          "hash": "sha256:13df11a7b04e504140de8d1a60b43dadcc686e8d3e7211a3e5e41610d0b7386a"
+        },
+        "shape": {
+          "path": "specs/ed/modules/design-system/design-system.shape.ttl",
+          "hash": "sha256:4e3fce060cc011c476ccf95cb68eaad407b8c4218aeea50a5cfd81036fbf65f8"
+        },
+        "ontology": {
+          "path": "specs/ed/modules/design-system/design-system.ttl",
+          "hash": "sha256:99d6c1eed040f3972333543f5081aa0e39cfb52cb6cb8bd88c251de532b08d81"
+        }
+      }
+    },
+    "experienceAnnotation": {
+      "moduleId": "modules/experience-annotation",
+      "contextUrl": "https://ujg.specs.openuji.org/ed/ns/experience-annotation.context.jsonld",
+      "artifacts": {
+        "context": {
+          "path": "specs/ed/modules/experience-annotation/experience-annotation.context.jsonld",
+          "hash": "sha256:92e0ce1aebcbf5f170e0e7faeec139eb182ef0b7134087380cebc0be8daa46c9"
+        },
+        "shape": {
+          "path": "specs/ed/modules/experience-annotation/experience-annotation.shape.ttl",
+          "hash": "sha256:b9ce04e5f20064808bc2626c27ca2f03590fbfc9c942460bab45dd406d557dfa"
+        },
+        "ontology": {
+          "path": "specs/ed/modules/experience-annotation/experience-annotation.ttl",
+          "hash": "sha256:21d5e2ab447248486e269925c8c44e1a95b2d3083ceb58c77cc2926743d1b7c6"
+        }
+      }
+    },
+    "stateData": {
+      "moduleId": "modules/state-data",
+      "contextUrl": "https://ujg.specs.openuji.org/ed/ns/state-data.context.jsonld",
+      "artifacts": {
+        "context": {
+          "path": "specs/ed/modules/state-data/state-data.context.jsonld",
+          "hash": "sha256:f916db2732131c3455a0680f499248e37d0d2fbccd7380af3d93474bc6d63f25"
+        },
+        "shape": {
+          "path": "specs/ed/modules/state-data/state-data.shape.ttl",
+          "hash": "sha256:5c6c7b7daf6d6368148ec172f200f151ec829802cc43c2b7d2ef6021f23ec14a"
+        },
+        "ontology": {
+          "path": "specs/ed/modules/state-data/state-data.ttl",
+          "hash": "sha256:13e4516f17377356a9de8c64b04d37437a9e7347defa44833667e3577c7ad432"
+        }
+      }
+    }
+  }
+}

--- a/packages/ujg-yaml/targets/ed-2026-07-13.vocab.json
+++ b/packages/ujg-yaml/targets/ed-2026-07-13.vocab.json
@@ -1,0 +1,2006 @@
+{
+  "classes": {
+    "AccessibleFeature": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/observability#AccessibleFeature",
+      "module": "observability"
+    },
+    "AccessibleLocator": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/observability#AccessibleLocator",
+      "module": "observability"
+    },
+    "AccessibleRelation": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/observability#AccessibleRelation",
+      "module": "observability"
+    },
+    "Action": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/action#Action",
+      "module": "action"
+    },
+    "Actor": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/graph#Actor",
+      "module": "graph"
+    },
+    "Artifact": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/artifact#Artifact",
+      "module": "artifact"
+    },
+    "Component": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/design-system#Component",
+      "module": "designSystem"
+    },
+    "CompositeState": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/graph#CompositeState",
+      "module": "graph"
+    },
+    "Condition": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/condition#Condition",
+      "module": "condition"
+    },
+    "ConditionSet": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/condition#ConditionSet",
+      "module": "condition"
+    },
+    "CustomLocator": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/observability#CustomLocator",
+      "module": "observability"
+    },
+    "DesignSystem": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/design-system#DesignSystem",
+      "module": "designSystem"
+    },
+    "DistributedArtifact": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/distributed-journey#DistributedArtifact",
+      "module": "distributedJourney"
+    },
+    "ExperienceStep": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/surface#ExperienceStep",
+      "module": "surface"
+    },
+    "Journey": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/graph#Journey",
+      "module": "graph"
+    },
+    "JourneyEntry": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/graph#JourneyEntry",
+      "module": "graph"
+    },
+    "JourneyEntryIndex": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/graph#JourneyEntryIndex",
+      "module": "graph"
+    },
+    "JourneyExecution": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/runtime#JourneyExecution",
+      "module": "runtime"
+    },
+    "JourneyExit": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/graph#JourneyExit",
+      "module": "graph"
+    },
+    "JourneyMapping": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/mapping#JourneyMapping",
+      "module": "mapping"
+    },
+    "LocalVertex": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/graph#LocalVertex",
+      "module": "graph"
+    },
+    "MappedStep": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/mapping#MappedStep",
+      "module": "mapping"
+    },
+    "MessageBundle": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/l10n#MessageBundle",
+      "module": "l10n"
+    },
+    "Node": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/core#Node",
+      "module": "core"
+    },
+    "ObservationBinding": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/observability#ObservationBinding",
+      "module": "observability"
+    },
+    "ObservationEvent": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/observability#ObservationEvent",
+      "module": "observability"
+    },
+    "OutgoingTransition": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/graph#OutgoingTransition",
+      "module": "graph"
+    },
+    "OutgoingTransitionGroup": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/graph#OutgoingTransitionGroup",
+      "module": "graph"
+    },
+    "PainPoint": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/experience-annotation#PainPoint",
+      "module": "experienceAnnotation"
+    },
+    "Phase": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/surface#Phase",
+      "module": "surface"
+    },
+    "Route": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/routing#Route",
+      "module": "routing"
+    },
+    "RuntimeEvent": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/runtime#RuntimeEvent",
+      "module": "runtime"
+    },
+    "Slot": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/design-system#Slot",
+      "module": "designSystem"
+    },
+    "SlotBinding": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/design-system#SlotBinding",
+      "module": "designSystem"
+    },
+    "State": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/graph#State",
+      "module": "graph"
+    },
+    "StateData": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/state-data#StateData",
+      "module": "stateData"
+    },
+    "Surface": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/surface#Surface",
+      "module": "surface"
+    },
+    "SurfaceInstance": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/surface#SurfaceInstance",
+      "module": "surface"
+    },
+    "SurfaceInstanceResolver": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/observability#SurfaceInstanceResolver",
+      "module": "observability"
+    },
+    "SurfaceRealization": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/design-system#SurfaceRealization",
+      "module": "designSystem"
+    },
+    "Template": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/design-system#Template",
+      "module": "designSystem"
+    },
+    "TokenSource": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/design-system#TokenSource",
+      "module": "designSystem"
+    },
+    "Touchpoint": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/surface#Touchpoint",
+      "module": "surface"
+    },
+    "Transition": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/graph#Transition",
+      "module": "graph"
+    },
+    "UJGDocument": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/core#UJGDocument",
+      "module": "core"
+    }
+  },
+  "contextOrder": [
+    "core",
+    "graph",
+    "surface",
+    "runtime",
+    "mapping",
+    "action",
+    "artifact",
+    "distributedJourney",
+    "condition",
+    "routing",
+    "designSystem",
+    "l10n",
+    "observability",
+    "experienceAnnotation",
+    "stateData"
+  ],
+  "generatedFrom": {
+    "artifactHashes": {
+      "specs/ed/core/core.context.jsonld": "sha256:c9c560f264ce95a506ed91802e749c7d417ed34728351840aebfae40c7733e3b",
+      "specs/ed/core/core.shape.ttl": "sha256:7dccb70ce37bc20a2c4687d9407db0ef4e64f4c207686fa9d22251bb03376611",
+      "specs/ed/core/core.ttl": "sha256:0d600641ac1b4fbe5c30a9a154945b0b91488ca23f741fc3355e4f02a7a7f686",
+      "specs/ed/graph/graph.context.jsonld": "sha256:c4a7198fa4ef6d7e9e835e82dd7f5ca3b8e7f565dad5833d157625c0dfb8a0c4",
+      "specs/ed/graph/graph.shape.ttl": "sha256:c4354a238747e8c9c53d57c320f7a17292d1814a2ff48f1cf31bc5884b0222ed",
+      "specs/ed/graph/graph.ttl": "sha256:9d5d9166ce3eaef4a96c043af9463e96fb12edf92937bb1633a6c391ab00e655",
+      "specs/ed/mapping/mapping.context.jsonld": "sha256:aed6286a0b0a9da31b1e2d4b71870c6c2bd80f02c54d68c592561f2014ad09a3",
+      "specs/ed/mapping/mapping.shape.ttl": "sha256:c7f2b3e605b13901a8aff9613c7a872f057230717e669099813b3aafce3c92ee",
+      "specs/ed/mapping/mapping.ttl": "sha256:b03175d4eef29870049a1f50b64b8a4dbca7504e05a154d2374eaae1ea55ea8c",
+      "specs/ed/modules/action/action.context.jsonld": "sha256:daf8a5ea6cf3602d980ec62648d7e51d1fc8147551f826f787b658dd7a2145b4",
+      "specs/ed/modules/action/action.shape.ttl": "sha256:54f5f0f8b2b58386f0ecb196620fdac2c8b98360bdf43194bc8c56ae1e19021d",
+      "specs/ed/modules/action/action.ttl": "sha256:be71cefcb4044d9f6ac82ec30620b5dd28bd55dae9d808802006fb03b4291c0a",
+      "specs/ed/modules/artifact/artifact.context.jsonld": "sha256:dcdbc3f77c9c4bd23f22a3b865e412705b831bca0f3f346144fc436b5544f09a",
+      "specs/ed/modules/artifact/artifact.shape.ttl": "sha256:927373c5a01af37d44f06f776695102d575cf17c883dff2ebeb470aefecdc0ee",
+      "specs/ed/modules/artifact/artifact.ttl": "sha256:adc9d6a74bad67d7ba44b75a47fa857df58f950afcebc4e4b4a8698c35e9d581",
+      "specs/ed/modules/condition/condition.context.jsonld": "sha256:db219d5cdcef0231575307c6cf31ecc5b59d2e49614e7dede652a9e481d4d62c",
+      "specs/ed/modules/condition/condition.shape.ttl": "sha256:d5437cbc5e6d3bf9ed9d049bc8165574a791f62f9c5f36d7e11c0001d4a387cf",
+      "specs/ed/modules/condition/condition.ttl": "sha256:3931d479f356643821498435c5694a77ac0aadeea72978e62521ba6b29c72bb8",
+      "specs/ed/modules/design-system/design-system.context.jsonld": "sha256:13df11a7b04e504140de8d1a60b43dadcc686e8d3e7211a3e5e41610d0b7386a",
+      "specs/ed/modules/design-system/design-system.shape.ttl": "sha256:4e3fce060cc011c476ccf95cb68eaad407b8c4218aeea50a5cfd81036fbf65f8",
+      "specs/ed/modules/design-system/design-system.ttl": "sha256:99d6c1eed040f3972333543f5081aa0e39cfb52cb6cb8bd88c251de532b08d81",
+      "specs/ed/modules/distributed-journey/distributed-journey.context.jsonld": "sha256:406e807bca61bb57e5ffc484a196ee06ff8f1ee39e925d11668c4b619c0b722a",
+      "specs/ed/modules/distributed-journey/distributed-journey.shape.ttl": "sha256:dcb4b6cbeca0fc337ed063af52541c96587c14d4dae2bb2dd0cc3d1b5389066b",
+      "specs/ed/modules/distributed-journey/distributed-journey.ttl": "sha256:79275d603cd6739c6f64f5ed2e2c9c5f8949621940d0b8129a9fef4e84e0c798",
+      "specs/ed/modules/experience-annotation/experience-annotation.context.jsonld": "sha256:92e0ce1aebcbf5f170e0e7faeec139eb182ef0b7134087380cebc0be8daa46c9",
+      "specs/ed/modules/experience-annotation/experience-annotation.shape.ttl": "sha256:b9ce04e5f20064808bc2626c27ca2f03590fbfc9c942460bab45dd406d557dfa",
+      "specs/ed/modules/experience-annotation/experience-annotation.ttl": "sha256:21d5e2ab447248486e269925c8c44e1a95b2d3083ceb58c77cc2926743d1b7c6",
+      "specs/ed/modules/l10n/l10n.context.jsonld": "sha256:c91b83268f1277fc51e3ce1dbd74d909ce1af6cad5237acb1e3bd8b8f9b608d2",
+      "specs/ed/modules/l10n/l10n.shape.ttl": "sha256:a32504d280e43c7f4567d18c709f8a96da3f7834acecff862f0e3c617a445eba",
+      "specs/ed/modules/l10n/l10n.ttl": "sha256:289c3eb4a4791e8f6961fe2c179e9735c20767c22055522e8b81800098aede9c",
+      "specs/ed/modules/observability/observability.context.jsonld": "sha256:10c123e8057dd455b492a60df8ba56369cc6782c4232856cd14426fc231a546b",
+      "specs/ed/modules/observability/observability.shape.ttl": "sha256:3d5eb3b941e41fa8670318a74b673b6e9855614350a5b1f6fc30a20c7e98643f",
+      "specs/ed/modules/observability/observability.ttl": "sha256:51751761af286066f747d208cc35a55a5c37a2ce356097c314db0584e96219ff",
+      "specs/ed/modules/routing/routing.context.jsonld": "sha256:e3db2488bdae5036c32dd9a0159c826ae9bd1024832a883b7c6175b7fd2619f8",
+      "specs/ed/modules/routing/routing.shape.ttl": "sha256:70d0a466e075d0aed933082acc5473773bc471099a18272a1bfc4570dca1ed40",
+      "specs/ed/modules/routing/routing.ttl": "sha256:3d3cefec8dee3a0a9a6776db624ab5e582e28da09395ca0f621f92348c2fcb8c",
+      "specs/ed/modules/state-data/state-data.context.jsonld": "sha256:f916db2732131c3455a0680f499248e37d0d2fbccd7380af3d93474bc6d63f25",
+      "specs/ed/modules/state-data/state-data.shape.ttl": "sha256:5c6c7b7daf6d6368148ec172f200f151ec829802cc43c2b7d2ef6021f23ec14a",
+      "specs/ed/modules/state-data/state-data.ttl": "sha256:13e4516f17377356a9de8c64b04d37437a9e7347defa44833667e3577c7ad432",
+      "specs/ed/runtime/runtime.context.jsonld": "sha256:4e52855fad3cf4722dc00d555520a445cbb240c655117e2532b62f72868ea438",
+      "specs/ed/runtime/runtime.shape.ttl": "sha256:88cfea86d2e43ab13f708f29c2deed3fd13241fe7875d1b79d254245891ab2e9",
+      "specs/ed/runtime/runtime.ttl": "sha256:e3cf150e9c8f7e365afdc6a3d7eeb80d93d17ab2f1c4f589791a0144017a4992",
+      "specs/ed/surface/surface.context.jsonld": "sha256:84e2964c55d18c0242dcafb974f2a2c52258c964be3671e011bdb53dd88d7fd4",
+      "specs/ed/surface/surface.shape.ttl": "sha256:60582dff0640d37f80e081e0b3eb023602821e2a8b0a378acacd396b06917ca9",
+      "specs/ed/surface/surface.ttl": "sha256:ab8849676f0e378f2a7dfe8b34aee83ace6949799b93e675510f6860293bd28f"
+    },
+    "targetSource": {
+      "edContentCommit": "a6a73ca56c25b48457c620af158acc6f68ac1f09",
+      "edContentDate": "2026-07-13T12:52:11+02:00",
+      "headCommit": "e795559ebea8a9f57e7d6d212ccb9fdd11e825d4",
+      "headDate": "2026-07-13T13:00:39+02:00",
+      "headSubject": "Merge pull request #15 from openuji/feature/surface-core"
+    }
+  },
+  "modules": {
+    "action": {
+      "contextUrl": "https://ujg.specs.openuji.org/ed/ns/action.context.jsonld",
+      "dependencies": [
+        "core",
+        "graph"
+      ]
+    },
+    "artifact": {
+      "contextUrl": "https://ujg.specs.openuji.org/ed/ns/artifact.context.jsonld",
+      "dependencies": [
+        "core"
+      ]
+    },
+    "condition": {
+      "contextUrl": "https://ujg.specs.openuji.org/ed/ns/condition.context.jsonld",
+      "dependencies": [
+        "core",
+        "graph"
+      ]
+    },
+    "core": {
+      "contextUrl": "https://ujg.specs.openuji.org/ed/ns/core.context.jsonld",
+      "dependencies": []
+    },
+    "designSystem": {
+      "contextUrl": "https://ujg.specs.openuji.org/ed/ns/design-system.context.jsonld",
+      "dependencies": [
+        "core",
+        "surface"
+      ]
+    },
+    "distributedJourney": {
+      "contextUrl": "https://ujg.specs.openuji.org/ed/ns/distributed-journey.context.jsonld",
+      "dependencies": [
+        "artifact",
+        "surface"
+      ]
+    },
+    "experienceAnnotation": {
+      "contextUrl": "https://ujg.specs.openuji.org/ed/ns/experience-annotation.context.jsonld",
+      "dependencies": [
+        "core",
+        "surface"
+      ]
+    },
+    "graph": {
+      "contextUrl": "https://ujg.specs.openuji.org/ed/ns/graph.context.jsonld",
+      "dependencies": [
+        "core"
+      ]
+    },
+    "l10n": {
+      "contextUrl": "https://ujg.specs.openuji.org/ed/ns/l10n.context.jsonld",
+      "dependencies": [
+        "core",
+        "graph"
+      ]
+    },
+    "mapping": {
+      "contextUrl": "https://ujg.specs.openuji.org/ed/ns/mapping.context.jsonld",
+      "dependencies": [
+        "core",
+        "graph",
+        "runtime"
+      ]
+    },
+    "observability": {
+      "contextUrl": "https://ujg.specs.openuji.org/ed/ns/observability.context.jsonld",
+      "dependencies": [
+        "core",
+        "l10n",
+        "surface"
+      ]
+    },
+    "routing": {
+      "contextUrl": "https://ujg.specs.openuji.org/ed/ns/routing.context.jsonld",
+      "dependencies": [
+        "core"
+      ]
+    },
+    "runtime": {
+      "contextUrl": "https://ujg.specs.openuji.org/ed/ns/runtime.context.jsonld",
+      "dependencies": [
+        "core",
+        "surface"
+      ]
+    },
+    "stateData": {
+      "contextUrl": "https://ujg.specs.openuji.org/ed/ns/state-data.context.jsonld",
+      "dependencies": [
+        "core",
+        "graph"
+      ]
+    },
+    "surface": {
+      "contextUrl": "https://ujg.specs.openuji.org/ed/ns/surface.context.jsonld",
+      "dependencies": [
+        "core",
+        "graph"
+      ]
+    }
+  },
+  "properties": {
+    "accessibleDescriptionRef": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/observability#accessibleDescriptionRef",
+      "kind": "object",
+      "module": "observability",
+      "reference": true,
+      "set": false
+    },
+    "accessibleFeatureName": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/observability#accessibleFeatureName",
+      "kind": "datatype",
+      "module": "observability",
+      "reference": false,
+      "set": false
+    },
+    "accessibleFeatureRefs": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/observability#accessibleFeatureRefs",
+      "kind": "object",
+      "module": "observability",
+      "reference": true,
+      "set": true
+    },
+    "accessibleFeatureValue": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/observability#accessibleFeatureValue",
+      "kind": "datatype",
+      "module": "observability",
+      "reference": false,
+      "set": false
+    },
+    "accessibleNameRef": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/observability#accessibleNameRef",
+      "kind": "object",
+      "module": "observability",
+      "reference": true,
+      "set": false
+    },
+    "accessibleRelationRefs": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/observability#accessibleRelationRefs",
+      "kind": "object",
+      "module": "observability",
+      "reference": true,
+      "set": true
+    },
+    "accessibleRelationType": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/observability#accessibleRelationType",
+      "kind": "datatype",
+      "module": "observability",
+      "reference": false,
+      "set": false
+    },
+    "actionRef": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/action#actionRef",
+      "kind": "object",
+      "module": "action",
+      "reference": true,
+      "set": false
+    },
+    "channel": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/surface#channel",
+      "kind": "datatype",
+      "module": "surface",
+      "reference": false,
+      "set": false
+    },
+    "componentRef": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/design-system#componentRef",
+      "kind": "object",
+      "module": "designSystem",
+      "reference": true,
+      "set": false
+    },
+    "componentRefs": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/design-system#componentRefs",
+      "kind": "object",
+      "module": "designSystem",
+      "reference": true,
+      "set": true
+    },
+    "conditionRef": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/condition#conditionRef",
+      "kind": "object",
+      "module": "condition",
+      "reference": true,
+      "set": false
+    },
+    "conditionTransitionRefs": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/condition#conditionTransitionRefs",
+      "kind": "object",
+      "module": "condition",
+      "reference": true,
+      "set": true
+    },
+    "consumedArtifactRefs": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/artifact#consumedArtifactRefs",
+      "kind": "object",
+      "module": "artifact",
+      "reference": true,
+      "set": true
+    },
+    "contextLocatorRefs": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/observability#contextLocatorRefs",
+      "kind": "object",
+      "module": "observability",
+      "reference": true,
+      "set": true
+    },
+    "copyRef": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/l10n#copyRef",
+      "kind": "object",
+      "module": "l10n",
+      "reference": true,
+      "set": false
+    },
+    "deepLink": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/routing#deepLink",
+      "kind": "datatype",
+      "module": "routing",
+      "reference": false,
+      "set": false
+    },
+    "defaultEntryRef": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/graph#defaultEntryRef",
+      "kind": "object",
+      "module": "graph",
+      "reference": true,
+      "set": false
+    },
+    "defaultLocale": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/l10n#defaultLocale",
+      "kind": "datatype",
+      "module": "l10n",
+      "reference": false,
+      "set": false
+    },
+    "description": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/experience-annotation#description",
+      "kind": "datatype",
+      "module": "experienceAnnotation",
+      "reference": false,
+      "set": false
+    },
+    "entryRefs": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/graph#entryRefs",
+      "kind": "object",
+      "module": "graph",
+      "reference": true,
+      "set": true
+    },
+    "executionId": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/runtime#executionId",
+      "kind": "object",
+      "module": "runtime",
+      "reference": true,
+      "set": false
+    },
+    "exitRefs": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/graph#exitRefs",
+      "kind": "object",
+      "module": "graph",
+      "reference": true,
+      "set": true
+    },
+    "experienceRefs": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/experience-annotation#experienceRefs",
+      "kind": "object",
+      "module": "experienceAnnotation",
+      "reference": true,
+      "set": true
+    },
+    "explainedByTransitionRef": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/mapping#explainedByTransitionRef",
+      "kind": "object",
+      "module": "mapping",
+      "reference": true,
+      "set": false
+    },
+    "extensions": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/core#extensions",
+      "kind": "datatype",
+      "module": "core",
+      "reference": false,
+      "set": false,
+      "type": "@json"
+    },
+    "fallbackLocales": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/l10n#fallbackLocales",
+      "kind": "datatype",
+      "module": "l10n",
+      "reference": false,
+      "set": true
+    },
+    "fallbackNodeRef": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/routing#fallbackNodeRef",
+      "kind": "object",
+      "module": "routing",
+      "reference": true,
+      "set": false
+    },
+    "from": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/graph#from",
+      "kind": "object",
+      "module": "graph",
+      "reference": true,
+      "set": false
+    },
+    "fromExitRef": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/graph#fromExitRef",
+      "kind": "object",
+      "module": "graph",
+      "reference": true,
+      "set": false
+    },
+    "graphNodeRef": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/surface#graphNodeRef",
+      "kind": "object",
+      "module": "surface",
+      "reference": true,
+      "set": false
+    },
+    "guards": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/routing#guards",
+      "kind": "datatype",
+      "module": "routing",
+      "reference": false,
+      "set": true
+    },
+    "imports": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/core#documentImports",
+      "kind": "object",
+      "module": "core",
+      "reference": true,
+      "set": true
+    },
+    "instanceKeyFeatureRef": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/observability#instanceKeyFeatureRef",
+      "kind": "object",
+      "module": "observability",
+      "reference": true,
+      "set": false
+    },
+    "l10n:targetLocale": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/l10n#targetLocale",
+      "kind": "datatype",
+      "module": "l10n",
+      "reference": false,
+      "set": false,
+      "type": "http://www.w3.org/2001/XMLSchema#language"
+    },
+    "label": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/graph#label",
+      "kind": "datatype",
+      "module": "graph",
+      "reference": false,
+      "set": false
+    },
+    "locales": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/l10n#locales",
+      "kind": "datatype",
+      "module": "l10n",
+      "reference": false,
+      "set": false,
+      "type": "@json"
+    },
+    "locatorRefs": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/observability#locatorRefs",
+      "kind": "object",
+      "module": "observability",
+      "reference": true,
+      "set": true
+    },
+    "mappedEventRef": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/mapping#mappedEventRef",
+      "kind": "object",
+      "module": "mapping",
+      "reference": true,
+      "set": false
+    },
+    "mappedJourneyRef": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/mapping#mappedJourneyRef",
+      "kind": "object",
+      "module": "mapping",
+      "reference": true,
+      "set": false
+    },
+    "mappedRuntimeRef": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/mapping#mappedRuntimeRef",
+      "kind": "object",
+      "module": "mapping",
+      "reference": true,
+      "set": false
+    },
+    "mappedStateRef": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/mapping#mappedStateRef",
+      "kind": "object",
+      "module": "mapping",
+      "reference": true,
+      "set": false
+    },
+    "mappedStepRef": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/mapping#mappedStepRef",
+      "kind": "object",
+      "module": "mapping",
+      "reference": true,
+      "set": true
+    },
+    "messageKey": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/l10n#messageKey",
+      "kind": "datatype",
+      "module": "l10n",
+      "reference": false,
+      "set": false
+    },
+    "namespace": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/l10n#namespace",
+      "kind": "datatype",
+      "module": "l10n",
+      "reference": false,
+      "set": false
+    },
+    "nodes": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/core#documentNodes",
+      "kind": "object",
+      "module": "core",
+      "reference": false,
+      "set": true
+    },
+    "observationEventRef": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/observability#observationEventRef",
+      "kind": "object",
+      "module": "observability",
+      "reference": true,
+      "set": false
+    },
+    "observedAffordanceEventRef": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/mapping#observedAffordanceEventRef",
+      "kind": "object",
+      "module": "mapping",
+      "reference": true,
+      "set": false
+    },
+    "observeSurfaceRef": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/observability#observeSurfaceRef",
+      "kind": "object",
+      "module": "observability",
+      "reference": true,
+      "set": false
+    },
+    "order": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/surface#order",
+      "kind": "datatype",
+      "module": "surface",
+      "reference": false,
+      "set": false
+    },
+    "origin": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/surface#origin",
+      "kind": "object",
+      "module": "surface",
+      "reference": true,
+      "set": false
+    },
+    "outgoingTransitionGroupRefs": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/graph#outgoingTransitionGroupRefs",
+      "kind": "object",
+      "module": "graph",
+      "reference": true,
+      "set": true
+    },
+    "outgoingTransitionRefs": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/graph#outgoingTransitionRefs",
+      "kind": "object",
+      "module": "graph",
+      "reference": true,
+      "set": true
+    },
+    "params": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/routing#params",
+      "kind": "datatype",
+      "module": "routing",
+      "reference": false,
+      "set": false,
+      "type": "@json"
+    },
+    "path": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/routing#path",
+      "kind": "datatype",
+      "module": "routing",
+      "reference": false,
+      "set": false
+    },
+    "payload": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/runtime#payload",
+      "kind": "datatype",
+      "module": "runtime",
+      "reference": false,
+      "set": false,
+      "type": "@json"
+    },
+    "phaseRef": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/surface#phaseRef",
+      "kind": "object",
+      "module": "surface",
+      "reference": true,
+      "set": false
+    },
+    "previousId": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/runtime#previousId",
+      "kind": "object",
+      "module": "runtime",
+      "reference": true,
+      "set": false
+    },
+    "producedArtifactRefs": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/artifact#producedArtifactRefs",
+      "kind": "object",
+      "module": "artifact",
+      "reference": true,
+      "set": true
+    },
+    "role": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/observability#role",
+      "kind": "datatype",
+      "module": "observability",
+      "reference": false,
+      "set": false
+    },
+    "routeName": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/routing#routeName",
+      "kind": "datatype",
+      "module": "routing",
+      "reference": false,
+      "set": false
+    },
+    "routeRef": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/routing#routeRef",
+      "kind": "object",
+      "module": "routing",
+      "reference": true,
+      "set": false
+    },
+    "rtl": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/l10n#rtl",
+      "kind": "datatype",
+      "module": "l10n",
+      "reference": false,
+      "set": false
+    },
+    "severity": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/experience-annotation#severity",
+      "kind": "datatype",
+      "module": "experienceAnnotation",
+      "reference": false,
+      "set": false,
+      "type": "http://www.w3.org/2001/XMLSchema#decimal"
+    },
+    "slotBindingRefs": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/design-system#slotBindingRefs",
+      "kind": "object",
+      "module": "designSystem",
+      "reference": true,
+      "set": true
+    },
+    "slotRef": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/design-system#slotRef",
+      "kind": "object",
+      "module": "designSystem",
+      "reference": true,
+      "set": false
+    },
+    "slotRefs": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/design-system#slotRefs",
+      "kind": "object",
+      "module": "designSystem",
+      "reference": true,
+      "set": true
+    },
+    "sourceTouchpointRef": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/distributed-journey#sourceTouchpointRef",
+      "kind": "object",
+      "module": "distributedJourney",
+      "reference": true,
+      "set": false
+    },
+    "stateDataRef": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/state-data#stateDataRef",
+      "kind": "object",
+      "module": "stateData",
+      "reference": true,
+      "set": false
+    },
+    "stateRef": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/graph#stateRef",
+      "kind": "object",
+      "module": "graph",
+      "reference": true,
+      "set": false
+    },
+    "stateRefs": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/graph#stateRefs",
+      "kind": "object",
+      "module": "graph",
+      "reference": true,
+      "set": true
+    },
+    "subjectActorRef": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/graph#subjectActorRef",
+      "kind": "object",
+      "module": "graph",
+      "reference": true,
+      "set": false
+    },
+    "subjourneyId": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/graph#subjourneyId",
+      "kind": "object",
+      "module": "graph",
+      "reference": true,
+      "set": false
+    },
+    "surfaceInstanceRef": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/runtime#surfaceInstanceRef",
+      "kind": "object",
+      "module": "runtime",
+      "reference": true,
+      "set": false
+    },
+    "surfaceInstanceResolverRef": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/observability#surfaceInstanceResolverRef",
+      "kind": "object",
+      "module": "observability",
+      "reference": true,
+      "set": false
+    },
+    "surfaceRealizationRefs": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/design-system#surfaceRealizationRefs",
+      "kind": "object",
+      "module": "designSystem",
+      "reference": true,
+      "set": true
+    },
+    "surfaceRef": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/surface#surfaceRef",
+      "kind": "object",
+      "module": "surface",
+      "reference": true,
+      "set": false
+    },
+    "surfaceRefs": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/surface#surfaceRefs",
+      "kind": "object",
+      "module": "surface",
+      "reference": true,
+      "set": true
+    },
+    "tags": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/graph#tags",
+      "kind": "datatype",
+      "module": "graph",
+      "reference": false,
+      "set": true
+    },
+    "targetComponentRef": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/design-system#targetComponentRef",
+      "kind": "object",
+      "module": "designSystem",
+      "reference": true,
+      "set": false
+    },
+    "targetLocale": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/l10n#targetLocale",
+      "kind": "datatype",
+      "module": "l10n",
+      "reference": false,
+      "set": false,
+      "type": "http://www.w3.org/2001/XMLSchema#language"
+    },
+    "targetLocatorRef": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/observability#targetLocatorRef",
+      "kind": "object",
+      "module": "observability",
+      "reference": true,
+      "set": false
+    },
+    "targetSurfaceRef": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/design-system#targetSurfaceRef",
+      "kind": "object",
+      "module": "designSystem",
+      "reference": true,
+      "set": false
+    },
+    "targetTouchpointRefs": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/distributed-journey#targetTouchpointRefs",
+      "kind": "object",
+      "module": "distributedJourney",
+      "reference": true,
+      "set": true
+    },
+    "templateRef": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/design-system#templateRef",
+      "kind": "object",
+      "module": "designSystem",
+      "reference": true,
+      "set": false
+    },
+    "templateRefs": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/design-system#templateRefs",
+      "kind": "object",
+      "module": "designSystem",
+      "reference": true,
+      "set": true
+    },
+    "to": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/graph#to",
+      "kind": "object",
+      "module": "graph",
+      "reference": true,
+      "set": false
+    },
+    "toCurrentState": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/graph#toCurrentState",
+      "kind": "datatype",
+      "module": "graph",
+      "reference": false,
+      "set": false,
+      "type": "http://www.w3.org/2001/XMLSchema#boolean"
+    },
+    "toEntryRef": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/graph#toEntryRef",
+      "kind": "object",
+      "module": "graph",
+      "reference": true,
+      "set": false
+    },
+    "tokenSourceRefs": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/design-system#tokenSourceRefs",
+      "kind": "object",
+      "module": "designSystem",
+      "reference": true,
+      "set": true
+    },
+    "touchpointRef": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/surface#touchpointRef",
+      "kind": "object",
+      "module": "surface",
+      "reference": true,
+      "set": false
+    },
+    "transitionRefs": {
+      "iri": "https://ujg.specs.openuji.org/ed/ns/graph#transitionRefs",
+      "kind": "object",
+      "module": "graph",
+      "reference": true,
+      "set": true
+    }
+  },
+  "propertyShapes": {
+    "accessibleDescriptionRef": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/l10n#MessageBundle",
+        "maxCount": 1,
+        "module": "observability",
+        "nodeKind": "IRI"
+      },
+      {
+        "minCount": 1,
+        "module": "observability"
+      }
+    ],
+    "accessibleFeatureName": [
+      {
+        "datatype": "http://www.w3.org/2001/XMLSchema#string",
+        "maxCount": 1,
+        "minCount": 1,
+        "module": "observability"
+      }
+    ],
+    "accessibleFeatureRefs": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/observability#AccessibleFeature",
+        "module": "observability",
+        "nodeKind": "IRI"
+      },
+      {
+        "minCount": 1,
+        "module": "observability"
+      }
+    ],
+    "accessibleFeatureValue": [
+      {
+        "datatype": "http://www.w3.org/2001/XMLSchema#string",
+        "maxCount": 1,
+        "minCount": 1,
+        "module": "observability"
+      }
+    ],
+    "accessibleNameRef": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/l10n#MessageBundle",
+        "maxCount": 1,
+        "module": "observability",
+        "nodeKind": "IRI"
+      },
+      {
+        "minCount": 1,
+        "module": "observability"
+      }
+    ],
+    "accessibleRelationRefs": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/observability#AccessibleRelation",
+        "module": "observability",
+        "nodeKind": "IRI"
+      },
+      {
+        "minCount": 1,
+        "module": "observability"
+      }
+    ],
+    "accessibleRelationType": [
+      {
+        "datatype": "http://www.w3.org/2001/XMLSchema#string",
+        "maxCount": 1,
+        "minCount": 1,
+        "module": "observability"
+      }
+    ],
+    "actionRef": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/action#Action",
+        "maxCount": 1,
+        "module": "action",
+        "nodeKind": "IRI"
+      }
+    ],
+    "channel": [
+      {
+        "datatype": "http://www.w3.org/2001/XMLSchema#string",
+        "maxCount": 1,
+        "module": "surface"
+      }
+    ],
+    "componentRef": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/design-system#Component",
+        "maxCount": 1,
+        "module": "designSystem",
+        "nodeKind": "IRI"
+      }
+    ],
+    "componentRefs": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/design-system#Component",
+        "module": "designSystem",
+        "nodeKind": "IRI"
+      }
+    ],
+    "conditionRef": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/condition#Condition",
+        "maxCount": 1,
+        "module": "condition",
+        "nodeKind": "IRI"
+      }
+    ],
+    "conditionTransitionRefs": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/graph#Transition",
+        "minCount": 2,
+        "module": "condition",
+        "nodeKind": "IRI"
+      }
+    ],
+    "consumedArtifactRefs": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/artifact#Artifact",
+        "module": "artifact",
+        "nodeKind": "IRI"
+      }
+    ],
+    "contextLocatorRefs": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/observability#AccessibleLocator",
+        "module": "observability",
+        "nodeKind": "IRI"
+      },
+      {
+        "minCount": 1,
+        "module": "observability"
+      }
+    ],
+    "copyRef": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/l10n#MessageBundle",
+        "maxCount": 1,
+        "module": "l10n",
+        "nodeKind": "IRI"
+      }
+    ],
+    "deepLink": [
+      {
+        "datatype": "http://www.w3.org/2001/XMLSchema#string",
+        "maxCount": 1,
+        "module": "routing"
+      }
+    ],
+    "defaultEntryRef": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/graph#JourneyEntry",
+        "maxCount": 1,
+        "minCount": 1,
+        "module": "graph",
+        "nodeKind": "IRI"
+      },
+      {
+        "maxCount": 0,
+        "module": "graph"
+      }
+    ],
+    "defaultLocale": [
+      {
+        "datatype": "http://www.w3.org/2001/XMLSchema#string",
+        "maxCount": 1,
+        "module": "l10n"
+      }
+    ],
+    "description": [
+      {
+        "datatype": "http://www.w3.org/2001/XMLSchema#string",
+        "maxCount": 1,
+        "module": "experienceAnnotation"
+      }
+    ],
+    "entryRefs": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/graph#JourneyEntry",
+        "minCount": 1,
+        "module": "graph",
+        "nodeKind": "IRI"
+      },
+      {
+        "maxCount": 0,
+        "module": "graph"
+      }
+    ],
+    "executionId": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/runtime#JourneyExecution",
+        "maxCount": 1,
+        "minCount": 1,
+        "module": "runtime",
+        "nodeKind": "IRI"
+      }
+    ],
+    "exitRefs": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/graph#JourneyExit",
+        "module": "graph",
+        "nodeKind": "IRI"
+      },
+      {
+        "maxCount": 0,
+        "module": "graph"
+      }
+    ],
+    "experienceRefs": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/surface#ExperienceStep",
+        "minCount": 1,
+        "module": "experienceAnnotation",
+        "nodeKind": "IRI"
+      }
+    ],
+    "explainedByTransitionRef": [
+      {
+        "maxCount": 1,
+        "module": "mapping",
+        "nodeShape": "https://ujg.specs.openuji.org/ed/ns/mapping.shape#TransitionLikeShape"
+      }
+    ],
+    "extensions": [
+      {
+        "datatype": "http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON",
+        "maxCount": 1,
+        "minCount": 1,
+        "module": "observability"
+      },
+      {
+        "datatype": "http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON",
+        "maxCount": 1,
+        "module": "core"
+      },
+      {
+        "maxCount": 0,
+        "module": "core"
+      }
+    ],
+    "fallbackLocales": [
+      {
+        "datatype": "http://www.w3.org/2001/XMLSchema#string",
+        "module": "l10n"
+      }
+    ],
+    "fallbackNodeRef": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/core#Node",
+        "maxCount": 1,
+        "module": "routing",
+        "nodeKind": "IRI"
+      }
+    ],
+    "from": [
+      {
+        "maxCount": 0,
+        "module": "graph"
+      },
+      {
+        "maxCount": 1,
+        "minCount": 1,
+        "module": "graph",
+        "nodeShape": "https://ujg.specs.openuji.org/ed/ns/graph.shape#StateLikeShape"
+      }
+    ],
+    "fromExitRef": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/graph#JourneyExit",
+        "maxCount": 1,
+        "module": "graph",
+        "nodeKind": "IRI"
+      },
+      {
+        "maxCount": 0,
+        "module": "graph"
+      }
+    ],
+    "graphNodeRef": [
+      {
+        "maxCount": 1,
+        "minCount": 1,
+        "module": "surface",
+        "nodeKind": "IRI",
+        "nodeShape": "https://ujg.specs.openuji.org/ed/ns/surface.shape#GraphNodeRefTargetShape"
+      }
+    ],
+    "guards": [
+      {
+        "datatype": "http://www.w3.org/2001/XMLSchema#string",
+        "module": "routing"
+      }
+    ],
+    "imports": [
+      {
+        "minCount": 0,
+        "module": "core",
+        "nodeKind": "IRI"
+      }
+    ],
+    "instanceKeyFeatureRef": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/observability#AccessibleFeature",
+        "maxCount": 1,
+        "minCount": 1,
+        "module": "observability",
+        "nodeKind": "IRI"
+      }
+    ],
+    "l10n:targetLocale": [
+      {
+        "datatype": "http://www.w3.org/2001/XMLSchema#language",
+        "maxCount": 1,
+        "module": "l10n"
+      }
+    ],
+    "label": [
+      {
+        "datatype": "http://www.w3.org/2001/XMLSchema#string",
+        "maxCount": 1,
+        "minCount": 1,
+        "module": "graph"
+      },
+      {
+        "datatype": "http://www.w3.org/2001/XMLSchema#string",
+        "maxCount": 1,
+        "minCount": 1,
+        "module": "graph"
+      },
+      {
+        "datatype": "http://www.w3.org/2001/XMLSchema#string",
+        "maxCount": 1,
+        "minCount": 1,
+        "module": "surface"
+      },
+      {
+        "datatype": "http://www.w3.org/2001/XMLSchema#string",
+        "maxCount": 1,
+        "module": "graph"
+      },
+      {
+        "datatype": "http://www.w3.org/2001/XMLSchema#string",
+        "maxCount": 1,
+        "module": "graph"
+      },
+      {
+        "datatype": "http://www.w3.org/2001/XMLSchema#string",
+        "maxCount": 1,
+        "module": "graph"
+      },
+      {
+        "datatype": "http://www.w3.org/2001/XMLSchema#string",
+        "maxCount": 1,
+        "module": "graph"
+      },
+      {
+        "datatype": "http://www.w3.org/2001/XMLSchema#string",
+        "maxCount": 1,
+        "module": "graph"
+      }
+    ],
+    "locales": [
+      {
+        "datatype": "http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON",
+        "maxCount": 1,
+        "module": "l10n"
+      }
+    ],
+    "locatorRefs": [
+      {
+        "minCount": 1,
+        "module": "observability",
+        "nodeKind": "IRI",
+        "nodeShape": "https://ujg.specs.openuji.org/ed/ns/observability.shape#LocatorShape"
+      }
+    ],
+    "mappedEventRef": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/runtime#RuntimeEvent",
+        "maxCount": 1,
+        "minCount": 1,
+        "module": "mapping",
+        "nodeKind": "IRI"
+      }
+    ],
+    "mappedJourneyRef": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/graph#Journey",
+        "maxCount": 1,
+        "minCount": 1,
+        "module": "mapping",
+        "nodeKind": "IRI"
+      }
+    ],
+    "mappedRuntimeRef": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/runtime#JourneyExecution",
+        "maxCount": 1,
+        "minCount": 1,
+        "module": "mapping",
+        "nodeKind": "IRI"
+      }
+    ],
+    "mappedStateRef": [
+      {
+        "maxCount": 1,
+        "minCount": 1,
+        "module": "mapping",
+        "nodeShape": "https://ujg.specs.openuji.org/ed/ns/mapping.shape#StateLikeShape"
+      }
+    ],
+    "mappedStepRef": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/mapping#MappedStep",
+        "minCount": 1,
+        "module": "mapping",
+        "nodeKind": "IRI"
+      }
+    ],
+    "messageKey": [
+      {
+        "datatype": "http://www.w3.org/2001/XMLSchema#string",
+        "maxCount": 1,
+        "minCount": 1,
+        "module": "l10n"
+      }
+    ],
+    "namespace": [
+      {
+        "datatype": "http://www.w3.org/2001/XMLSchema#string",
+        "maxCount": 1,
+        "module": "l10n"
+      }
+    ],
+    "nodes": [
+      {
+        "minCount": 0,
+        "module": "core",
+        "nodeKind": "IRI"
+      }
+    ],
+    "observationEventRef": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/observability#ObservationEvent",
+        "maxCount": 1,
+        "minCount": 1,
+        "module": "observability",
+        "nodeKind": "IRI"
+      }
+    ],
+    "observedAffordanceEventRef": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/runtime#RuntimeEvent",
+        "maxCount": 1,
+        "module": "mapping",
+        "nodeKind": "IRI"
+      }
+    ],
+    "observeSurfaceRef": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/surface#Surface",
+        "maxCount": 1,
+        "minCount": 1,
+        "module": "observability",
+        "nodeKind": "IRI"
+      }
+    ],
+    "order": [
+      {
+        "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+        "maxCount": 1,
+        "module": "surface"
+      },
+      {
+        "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+        "maxCount": 1,
+        "module": "surface"
+      }
+    ],
+    "origin": [
+      {
+        "maxCount": 1,
+        "module": "surface",
+        "nodeKind": "IRI"
+      }
+    ],
+    "outgoingTransitionGroupRefs": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/graph#OutgoingTransitionGroup",
+        "module": "graph",
+        "nodeKind": "IRI"
+      },
+      {
+        "maxCount": 0,
+        "module": "graph"
+      }
+    ],
+    "outgoingTransitionRefs": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/graph#OutgoingTransition",
+        "minCount": 1,
+        "module": "graph",
+        "nodeKind": "IRI"
+      },
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/graph#OutgoingTransition",
+        "module": "graph",
+        "nodeKind": "IRI"
+      },
+      {
+        "maxCount": 0,
+        "module": "graph"
+      },
+      {
+        "maxCount": 0,
+        "module": "graph"
+      },
+      {
+        "maxCount": 0,
+        "module": "graph"
+      }
+    ],
+    "params": [
+      {
+        "datatype": "http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON",
+        "maxCount": 1,
+        "module": "routing"
+      }
+    ],
+    "path": [
+      {
+        "datatype": "http://www.w3.org/2001/XMLSchema#string",
+        "maxCount": 1,
+        "minCount": 1,
+        "module": "routing"
+      }
+    ],
+    "payload": [
+      {
+        "datatype": "http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON",
+        "maxCount": 1,
+        "module": "runtime"
+      }
+    ],
+    "phaseRef": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/surface#Phase",
+        "maxCount": 1,
+        "module": "surface",
+        "nodeKind": "IRI"
+      }
+    ],
+    "previousId": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/runtime#RuntimeEvent",
+        "maxCount": 1,
+        "module": "runtime",
+        "nodeKind": "IRI"
+      }
+    ],
+    "producedArtifactRefs": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/artifact#Artifact",
+        "module": "artifact",
+        "nodeKind": "IRI"
+      }
+    ],
+    "role": [
+      {
+        "datatype": "http://www.w3.org/2001/XMLSchema#string",
+        "maxCount": 1,
+        "module": "observability"
+      },
+      {
+        "minCount": 1,
+        "module": "observability"
+      }
+    ],
+    "routeName": [
+      {
+        "datatype": "http://www.w3.org/2001/XMLSchema#string",
+        "maxCount": 1,
+        "minCount": 1,
+        "module": "routing"
+      }
+    ],
+    "routeRef": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/routing#Route",
+        "maxCount": 1,
+        "module": "routing",
+        "nodeKind": "IRI"
+      }
+    ],
+    "rtl": [
+      {
+        "datatype": "http://www.w3.org/2001/XMLSchema#boolean",
+        "maxCount": 1,
+        "module": "l10n"
+      }
+    ],
+    "severity": [
+      {
+        "datatype": "http://www.w3.org/2001/XMLSchema#decimal",
+        "maxCount": 1,
+        "module": "experienceAnnotation"
+      }
+    ],
+    "slotBindingRefs": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/design-system#SlotBinding",
+        "module": "designSystem",
+        "nodeKind": "IRI"
+      }
+    ],
+    "slotRef": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/design-system#Slot",
+        "maxCount": 1,
+        "minCount": 1,
+        "module": "designSystem",
+        "nodeKind": "IRI"
+      }
+    ],
+    "slotRefs": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/design-system#Slot",
+        "module": "designSystem",
+        "nodeKind": "IRI"
+      }
+    ],
+    "sourceTouchpointRef": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/surface#Touchpoint",
+        "maxCount": 1,
+        "module": "distributedJourney",
+        "nodeKind": "IRI"
+      },
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/surface#Touchpoint",
+        "maxCount": 1,
+        "module": "distributedJourney",
+        "nodeKind": "IRI"
+      }
+    ],
+    "stateDataRef": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/state-data#StateData",
+        "maxCount": 1,
+        "module": "stateData",
+        "nodeKind": "IRI"
+      }
+    ],
+    "stateRef": [
+      {
+        "maxCount": 0,
+        "module": "graph"
+      },
+      {
+        "maxCount": 1,
+        "minCount": 1,
+        "module": "graph",
+        "nodeShape": "https://ujg.specs.openuji.org/ed/ns/graph.shape#StateLikeShape"
+      }
+    ],
+    "stateRefs": [
+      {
+        "maxCount": 0,
+        "module": "graph"
+      },
+      {
+        "minCount": 1,
+        "module": "graph",
+        "nodeShape": "https://ujg.specs.openuji.org/ed/ns/graph.shape#IndexStateShape"
+      },
+      {
+        "minCount": 1,
+        "module": "graph",
+        "nodeShape": "https://ujg.specs.openuji.org/ed/ns/graph.shape#StateLikeShape"
+      }
+    ],
+    "subjectActorRef": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/graph#Actor",
+        "maxCount": 1,
+        "module": "graph",
+        "nodeKind": "IRI"
+      },
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/graph#Actor",
+        "maxCount": 1,
+        "module": "graph",
+        "nodeKind": "IRI"
+      }
+    ],
+    "subjourneyId": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/graph#Journey",
+        "maxCount": 1,
+        "minCount": 1,
+        "module": "graph",
+        "nodeKind": "IRI"
+      },
+      {
+        "maxCount": 0,
+        "module": "graph"
+      }
+    ],
+    "surfaceInstanceRef": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/surface#SurfaceInstance",
+        "maxCount": 1,
+        "minCount": 1,
+        "module": "runtime",
+        "nodeKind": "IRI"
+      }
+    ],
+    "surfaceInstanceResolverRef": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/observability#SurfaceInstanceResolver",
+        "maxCount": 1,
+        "module": "observability",
+        "nodeKind": "IRI"
+      }
+    ],
+    "surfaceRealizationRefs": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/design-system#SurfaceRealization",
+        "module": "designSystem",
+        "nodeKind": "IRI"
+      }
+    ],
+    "surfaceRef": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/surface#Surface",
+        "maxCount": 1,
+        "minCount": 1,
+        "module": "designSystem",
+        "nodeKind": "IRI"
+      },
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/surface#Surface",
+        "maxCount": 1,
+        "minCount": 1,
+        "module": "surface",
+        "nodeKind": "IRI"
+      }
+    ],
+    "surfaceRefs": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/surface#Surface",
+        "minCount": 1,
+        "module": "surface",
+        "nodeKind": "IRI"
+      }
+    ],
+    "tags": [
+      {
+        "datatype": "http://www.w3.org/2001/XMLSchema#string",
+        "module": "graph"
+      },
+      {
+        "datatype": "http://www.w3.org/2001/XMLSchema#string",
+        "module": "graph"
+      },
+      {
+        "datatype": "http://www.w3.org/2001/XMLSchema#string",
+        "module": "graph"
+      },
+      {
+        "datatype": "http://www.w3.org/2001/XMLSchema#string",
+        "module": "graph"
+      },
+      {
+        "datatype": "http://www.w3.org/2001/XMLSchema#string",
+        "module": "graph"
+      }
+    ],
+    "targetComponentRef": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/design-system#Component",
+        "maxCount": 1,
+        "module": "designSystem",
+        "nodeKind": "IRI"
+      }
+    ],
+    "targetLocatorRef": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/observability#AccessibleLocator",
+        "maxCount": 1,
+        "minCount": 1,
+        "module": "observability",
+        "nodeKind": "IRI"
+      }
+    ],
+    "targetSurfaceRef": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/surface#Surface",
+        "maxCount": 1,
+        "module": "designSystem",
+        "nodeKind": "IRI"
+      }
+    ],
+    "targetTouchpointRefs": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/surface#Touchpoint",
+        "module": "distributedJourney",
+        "nodeKind": "IRI"
+      },
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/surface#Touchpoint",
+        "module": "distributedJourney",
+        "nodeKind": "IRI"
+      }
+    ],
+    "templateRef": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/design-system#Template",
+        "maxCount": 1,
+        "module": "designSystem",
+        "nodeKind": "IRI"
+      }
+    ],
+    "templateRefs": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/design-system#Template",
+        "module": "designSystem",
+        "nodeKind": "IRI"
+      }
+    ],
+    "to": [
+      {
+        "maxCount": 0,
+        "module": "graph"
+      },
+      {
+        "maxCount": 1,
+        "minCount": 1,
+        "module": "graph",
+        "nodeShape": "https://ujg.specs.openuji.org/ed/ns/graph.shape#LocalVertexShape"
+      },
+      {
+        "maxCount": 1,
+        "module": "graph",
+        "nodeShape": "https://ujg.specs.openuji.org/ed/ns/graph.shape#OutgoingTargetShape"
+      }
+    ],
+    "toCurrentState": [
+      {
+        "datatype": "http://www.w3.org/2001/XMLSchema#boolean",
+        "maxCount": 1,
+        "module": "graph"
+      }
+    ],
+    "toEntryRef": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/graph#JourneyEntry",
+        "maxCount": 1,
+        "module": "graph",
+        "nodeKind": "IRI"
+      },
+      {
+        "maxCount": 0,
+        "module": "graph"
+      }
+    ],
+    "tokenSourceRefs": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/design-system#TokenSource",
+        "module": "designSystem",
+        "nodeKind": "IRI"
+      }
+    ],
+    "touchpointRef": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/surface#Touchpoint",
+        "maxCount": 1,
+        "module": "surface",
+        "nodeKind": "IRI"
+      }
+    ],
+    "transitionRefs": [
+      {
+        "classIri": "https://ujg.specs.openuji.org/ed/ns/graph#Transition",
+        "module": "graph",
+        "nodeKind": "IRI"
+      },
+      {
+        "maxCount": 0,
+        "module": "graph"
+      }
+    ]
+  },
+  "referenceProperties": [
+    "accessibleDescriptionRef",
+    "accessibleFeatureRefs",
+    "accessibleNameRef",
+    "accessibleRelationRefs",
+    "actionRef",
+    "componentRef",
+    "componentRefs",
+    "conditionRef",
+    "conditionTransitionRefs",
+    "consumedArtifactRefs",
+    "contextLocatorRefs",
+    "copyRef",
+    "defaultEntryRef",
+    "entryRefs",
+    "executionId",
+    "exitRefs",
+    "experienceRefs",
+    "explainedByTransitionRef",
+    "fallbackNodeRef",
+    "from",
+    "fromExitRef",
+    "graphNodeRef",
+    "imports",
+    "instanceKeyFeatureRef",
+    "locatorRefs",
+    "mappedEventRef",
+    "mappedJourneyRef",
+    "mappedRuntimeRef",
+    "mappedStateRef",
+    "mappedStepRef",
+    "observationEventRef",
+    "observeSurfaceRef",
+    "observedAffordanceEventRef",
+    "origin",
+    "outgoingTransitionGroupRefs",
+    "outgoingTransitionRefs",
+    "phaseRef",
+    "previousId",
+    "producedArtifactRefs",
+    "routeRef",
+    "slotBindingRefs",
+    "slotRef",
+    "slotRefs",
+    "sourceTouchpointRef",
+    "stateDataRef",
+    "stateRef",
+    "stateRefs",
+    "subjectActorRef",
+    "subjourneyId",
+    "surfaceInstanceRef",
+    "surfaceInstanceResolverRef",
+    "surfaceRealizationRefs",
+    "surfaceRef",
+    "surfaceRefs",
+    "targetComponentRef",
+    "targetLocatorRef",
+    "targetSurfaceRef",
+    "targetTouchpointRefs",
+    "templateRef",
+    "templateRefs",
+    "to",
+    "toEntryRef",
+    "tokenSourceRefs",
+    "touchpointRef",
+    "transitionRefs"
+  ],
+  "setProperties": [
+    "accessibleFeatureRefs",
+    "accessibleRelationRefs",
+    "componentRefs",
+    "conditionTransitionRefs",
+    "consumedArtifactRefs",
+    "contextLocatorRefs",
+    "entryRefs",
+    "exitRefs",
+    "experienceRefs",
+    "fallbackLocales",
+    "guards",
+    "imports",
+    "locatorRefs",
+    "mappedStepRef",
+    "nodes",
+    "outgoingTransitionGroupRefs",
+    "outgoingTransitionRefs",
+    "producedArtifactRefs",
+    "slotBindingRefs",
+    "slotRefs",
+    "stateRefs",
+    "surfaceRealizationRefs",
+    "surfaceRefs",
+    "tags",
+    "targetTouchpointRefs",
+    "templateRefs",
+    "tokenSourceRefs",
+    "transitionRefs"
+  ],
+  "targetId": "ed-2026-07-13"
+}

--- a/packages/ujg-yaml/tests/converter.test.js
+++ b/packages/ujg-yaml/tests/converter.test.js
@@ -1,0 +1,217 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+import {
+  compileAuthoringYaml,
+  listTargets,
+  loadTarget,
+  projectCanonicalJsonLd,
+  validateCanonicalJsonLd,
+} from '../src/index.js';
+import { projectionRegistryDiagnostics } from '../src/registry.js';
+import {
+  buildVocabularyForTargetId,
+  stringifyVocabulary,
+} from '../scripts/build-target-vocabulary.js';
+
+test('lists the locked ed-2026-07-13 target', () => {
+  assert.deepEqual(listTargets(), ['ed-2026-07-13']);
+});
+
+test('loads generated vocabulary from the locked target', async () => {
+  const target = await loadTarget('ed-2026-07-13');
+
+  assert.equal(target.vocabulary.targetId, 'ed-2026-07-13');
+  assert.equal(target.vocabulary.classes.Journey.module, 'graph');
+  assert.equal(target.vocabulary.properties.stateDataRef.module, 'stateData');
+  assert.ok(target.vocabulary.referenceProperties.includes('stateDataRef'));
+});
+
+test('generated vocabulary is deterministic', async () => {
+  const generated = stringifyVocabulary(await buildVocabularyForTargetId('ed-2026-07-13'));
+  const locked = await readFile(
+    new URL('../targets/ed-2026-07-13.vocab.json', import.meta.url),
+    'utf8'
+  );
+
+  assert.equal(generated, locked);
+});
+
+test('projection registry validates against target vocabulary', async () => {
+  const target = await loadTarget('ed-2026-07-13');
+  const diagnostics = projectionRegistryDiagnostics({
+    ...target.vocabulary,
+    classes: {
+      ...target.vocabulary.classes,
+      Touchpoint: undefined,
+    },
+  });
+
+  assert.ok(diagnostics.some((message) => message.includes('Touchpoint')));
+});
+
+test('compiles the complex fixture to deterministic canonical JSON-LD', async () => {
+  const source = await readFile(new URL('../fixtures/complex.yaml', import.meta.url), 'utf8');
+  const result = await compileAuthoringYaml(source);
+
+  assert.equal(result.ok, true);
+  assert.equal(result.provenance.ujgTarget, 'ed-2026-07-13');
+  assert.equal(result.document['@type'], 'UJGDocument');
+  assert.ok(result.document['@context'].includes('https://ujg.specs.openuji.org/ed/ns/core.context.jsonld'));
+  assert.ok(result.document.nodes.some((node) => node['@type'] === 'JourneyEntryIndex'));
+  assert.ok(result.document.nodes.some((node) => node['@type'] === 'DistributedArtifact'));
+  assert.ok(result.document.nodes.some((node) => node['@type'] === 'AccessibleLocator'));
+});
+
+test('compiles the auth fixture and preserves sampleScreenRef as a namespaced extension', async () => {
+  const source = await readFile(new URL('../fixtures/auth.yaml', import.meta.url), 'utf8');
+  const result = await compileAuthoringYaml(source);
+
+  assert.equal(result.ok, true);
+  const surface = result.document.nodes.find((node) => node['@id'] === 'app-sign-in-required-surface');
+  assert.equal(
+    surface.extensions['https://openuji.org/ujg-yaml/extensions#sampleScreenRef'],
+    'screens/app-sign-in-required.png'
+  );
+});
+
+test('uses keyed map keys as canonical ids and accepts matching body ids', async () => {
+  const result = await compileAuthoringYaml(`ujgTarget: ed-2026-07-13
+actions:
+  urn:action:key-only:
+    label: Key only
+  urn:action:matching-id:
+    id: urn:action:matching-id
+    label: Matching id
+  urn:action:matching-at-id:
+    "@id": urn:action:matching-at-id
+    label: Matching @id
+`);
+
+  assert.equal(result.ok, true);
+  assert.ok(result.document.nodes.some((node) => node['@id'] === 'urn:action:key-only'));
+  assert.ok(result.document.nodes.some((node) => node['@id'] === 'urn:action:matching-id'));
+  assert.ok(result.document.nodes.some((node) => node['@id'] === 'urn:action:matching-at-id'));
+});
+
+test('rejects keyed map entries whose body id conflicts with the key', async () => {
+  const result = await compileAuthoringYaml(`ujgTarget: ed-2026-07-13
+actions:
+  urn:action:key:
+    id: urn:action:other
+    label: Conflicting id
+`);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.diagnostics[0].code, 'ID_CONFLICT');
+});
+
+test('projects compiled JSON-LD to literal canonical nodes that compile again', async () => {
+  const source = await readFile(new URL('../fixtures/complex.yaml', import.meta.url), 'utf8');
+  const compiled = await compileAuthoringYaml(source);
+  const projected = await projectCanonicalJsonLd(compiled.document);
+  const recompiled = await compileAuthoringYaml(projected.yaml);
+
+  assert.equal(projected.ok, true);
+  assert.equal(recompiled.ok, true);
+  assert.equal(projected.authoring.ujgTarget, 'ed-2026-07-13');
+  assert.equal(projected.authoring.journey, undefined);
+  assert.ok(Array.isArray(projected.authoring.nodes));
+  assert.deepEqual(recompiled.document.nodes, compiled.document.nodes);
+});
+
+test('projects canonical JSON-LD without authoring sugar', async () => {
+  const projected = await projectCanonicalJsonLd({
+    '@context': [
+      'https://ujg.specs.openuji.org/ed/ns/core.context.jsonld',
+      'https://ujg.specs.openuji.org/ed/ns/graph.context.jsonld',
+      'https://ujg.specs.openuji.org/ed/ns/surface.context.jsonld',
+      'https://ujg.specs.openuji.org/ed/ns/action.context.jsonld',
+      'https://ujg.specs.openuji.org/ed/ns/l10n.context.jsonld',
+    ],
+    '@id': 'urn:document:test',
+    '@type': 'UJGDocument',
+    nodes: [
+      { '@id': 'urn:action:submit', '@type': 'Action', label: 'Submit' },
+      { '@id': 'urn:entry:start', '@type': 'JourneyEntry', stateRef: 'urn:state:start' },
+      {
+        '@id': 'urn:journey:test',
+        '@type': 'Journey',
+        entryRefs: ['urn:entry:start'],
+        stateRefs: ['urn:state:start'],
+        transitionRefs: ['urn:transition:submit'],
+      },
+      { '@id': 'urn:locator:submit', '@type': 'AccessibleLocator', role: 'button' },
+      { '@id': 'urn:message:submit', '@type': 'MessageBundle', messageKey: 'submit' },
+      { '@id': 'urn:state:orphan', '@type': 'State', label: 'Orphan state' },
+      { '@id': 'urn:state:start', '@type': 'State' },
+      { '@id': 'urn:surface:start', '@type': 'Surface', graphNodeRef: 'urn:state:start' },
+      { '@id': 'urn:transition:submit', '@type': 'Transition', from: 'urn:state:start', to: 'urn:state:end' },
+    ],
+  });
+
+  assert.equal(projected.ok, true);
+  assert.equal(projected.authoring.actions, undefined);
+  assert.equal(projected.authoring.journey, undefined);
+  assert.equal(projected.authoring.nodes[0].id, 'urn:action:submit');
+  assert.equal(projected.authoring.nodes[0].type, 'Action');
+  assert.ok(projected.authoring.nodes.some((node) => node.id === 'urn:surface:start'));
+  assert.ok(projected.yaml.includes('nodes:'));
+  assert.equal(/^\s+surface:/m.test(projected.yaml), false);
+  assert.equal(/^\s+transitions:/m.test(projected.yaml), false);
+});
+
+test('rejects canonical projection that would lose document-level data', async () => {
+  const projected = await projectCanonicalJsonLd({
+    '@context': ['https://ujg.specs.openuji.org/ed/ns/core.context.jsonld'],
+    '@id': 'urn:document:test',
+    '@type': 'UJGDocument',
+    imports: ['urn:document:imported'],
+    nodes: [],
+  });
+
+  assert.equal(projected.ok, false);
+  assert.equal(projected.diagnostics[0].code, 'LOSSY_PROJECTION');
+});
+
+test('round-trip validation passes strict structural canonical equivalence', async () => {
+  const source = await readFile(new URL('../fixtures/auth.yaml', import.meta.url), 'utf8');
+  const compiled = await compileAuthoringYaml(source);
+  const validation = await validateCanonicalJsonLd(compiled.document);
+
+  assert.equal(validation.ok, true);
+  assert.deepEqual(validation.diagnostics, []);
+});
+
+test('rejects YAML without ujgTarget', async () => {
+  const result = await compileAuthoringYaml('touchpoints: {}\n');
+
+  assert.equal(result.ok, false);
+  assert.equal(result.diagnostics[0].code, 'CONTEXT_NOT_LOCKED');
+});
+
+test('accepts target vocabulary terms that are not in the projection property order', async () => {
+  const result = await compileAuthoringYaml(`ujgTarget: ed-2026-07-13
+states:
+  app-state:
+    label: App state
+    stateDataRef: urn:external:state-data
+`);
+
+  assert.equal(result.ok, true);
+  assert.ok(
+    result.document['@context'].includes('https://ujg.specs.openuji.org/ed/ns/state-data.context.jsonld')
+  );
+  assert.equal(result.document.nodes[0].stateDataRef, 'urn:external:state-data');
+});
+
+test('rejects properties absent from the target vocabulary', async () => {
+  const result = await compileAuthoringYaml(`ujgTarget: ed-2026-07-13
+touchpoints:
+  app:
+    notInTheOntology: true
+`);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.diagnostics[0].code, 'UNKNOWN_AUTHORING_TERM');
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,15 @@ importers:
 
   packages/ujg-agent-pack: {}
 
+  packages/ujg-yaml:
+    dependencies:
+      n3:
+        specifier: ^2.1.1
+        version: 2.1.1
+      yaml:
+        specifier: ^2.8.1
+        version: 2.8.2
+
 packages:
 
   '@antfu/install-pkg@1.1.0':
@@ -673,89 +682,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1168,66 +1193,79 @@ packages:
     resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.57.1':
     resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.57.1':
     resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.57.1':
     resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.57.1':
     resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.57.1':
     resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.57.1':
     resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.57.1':
     resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.57.1':
     resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.57.1':
     resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.57.1':
     resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.57.1':
     resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.57.1':
     resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.57.1':
     resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
@@ -1336,24 +1374,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -1616,6 +1658,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -2616,24 +2659,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -2905,6 +2952,10 @@ packages:
 
   n3@1.26.0:
     resolution: {integrity: sha512-SQknS0ua90rN+3RHuk8BeIqeYyqIH/+ecViZxX08jR4j6MugqWRjtONl3uANG/crWXnOM2WIqBJtjIhVYFha+w==}
+    engines: {node: '>=12.0'}
+
+  n3@2.1.1:
+    resolution: {integrity: sha512-kqg8ers6Lc+uAmHeS+ycd3b8mC4x8wr8V8Fi6+w7l4hX6b0KZ5bT05Tf49qM2mujwaqZT3+08zcgtXgfxivbVQ==}
     engines: {node: '>=12.0'}
 
   nano-spawn@2.0.0:
@@ -3390,6 +3441,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -6928,6 +6980,11 @@ snapshots:
   ms@2.1.3: {}
 
   n3@1.26.0:
+    dependencies:
+      buffer: 6.0.3
+      readable-stream: 4.7.0
+
+  n3@2.1.1:
     dependencies:
       buffer: 6.0.3
       readable-stream: 4.7.0


### PR DESCRIPTION
## Summary

- Reset reverse projection to a strict literal `nodes:` baseline with no authoring sugar.
- Added compile support for top-level canonical `nodes:` YAML.
- Added strict `compile(project(canonical))` normalized-node equivalence checks.
- Added `LOSSY_PROJECTION` failures for canonical inputs that would drop unsupported data.
- Preserved keyed-map identity handling: map keys define node IDs, matching body `id`/`@id` is accepted, conflicts fail with `ID_CONFLICT`.

## Testing

- `pnpm -F @openuji/ujg-yaml test`
- `pnpm -F @openuji/ujg-yaml check`

## Notes

Reverse projection now intentionally avoids grouping, nesting, type omission, surface sugar, and transition sugar. Future authoring sugar should be added one explicit registry rule at a time, with equivalence tests.