### PR TITLE
make defaultEntryRef optional

### DIFF
--- a/packages/ujg-agent-pack/agents/ed/graph/AGENTS.md
+++ b/packages/ujg-agent-pack/agents/ed/graph/AGENTS.md
@@ -56,7 +56,9 @@ Prefer the shallowest valid graph.
 
 Use `JourneyEntryIndex` for catalogues, product-surface indexes, documentation indexes, or collections of known `JourneyEntry` contracts. Do not use it as a traversable journey.
 
-Use `Journey` only for local traversable topology. A journey must have an IRI `@id`, exactly one `defaultEntryRef`, at least one `entryRefs` value, and at least one `stateRefs` value. Its local vertices are `stateRefs` union `exitRefs`.
+Use `Journey` only for local traversable topology. A journey must have an IRI `@id`, at least one `entryRefs` value, and at least one `stateRefs` value. It may have at most one `defaultEntryRef`. Its local vertices are `stateRefs` union `exitRefs`.
+
+Do not infer a default entry from `entryRefs` ordering. If no entry is explicitly selected and no `defaultEntryRef` exists, entry selection remains unresolved by Graph and must be resolved externally by materialization or execution context. Graph does not define predicates, application-state expressions, domain-state mappings, or evaluation rules for contextual entry resolution.
 
 Use `JourneyEntry` for explicit journey entry contracts. Each entry must have exactly one `stateRef` that points to a `State` or `CompositeState` in the same journey's `stateRefs`. A `JourneyEntry` is not a transition endpoint.
 
@@ -64,7 +66,7 @@ Use ordinary `State` and local `Transition` for stable conditions on the same pa
 
 Use `CompositeState` only when a parent journey contains or exposes a nested journey with `subjourneyId`.
 
-Use `toEntryRef` only when a parent transition into a `CompositeState` must select a specific child `JourneyEntry`; otherwise the child journey starts at its `defaultEntryRef`.
+Use `toEntryRef` only when a parent transition into a `CompositeState` must select a specific child `JourneyEntry`. Otherwise the child journey starts at its `defaultEntryRef` when one exists. If neither `toEntryRef` nor child `defaultEntryRef` exists, the child entry remains unresolved by Graph and must be resolved externally by materialization or execution context. Do not infer a child entry from `entryRefs` ordering.
 
 Use `JourneyExit` and `fromExitRef` only for exported child outcomes that a parent genuinely reacts to. Model the child outcome as a direct terminal `JourneyExit`, not as a pseudo-state.
 

--- a/packages/ujg-agent-pack/agents/ed/root/AGENTS.md
+++ b/packages/ujg-agent-pack/agents/ed/root/AGENTS.md
@@ -110,7 +110,7 @@ Classify each modeled item before writing JSON-LD: index entry, page/surface ent
 
 Do not mix roles accidentally.
 
-If a component is modeled as a child journey, keep the full pattern coherent: parent `CompositeState`; exactly one `subjourneyId`; no child states in parent `stateRefs`; child states and transitions stay in child journey; child traversal starts at the child journey's `defaultEntryRef` unless the parent transition into the composite declares `toEntryRef`; exported outcome is a child-local terminal `JourneyExit` listed in child `exitRefs`; parent continuation is a parent-local `Transition` from the `CompositeState` to another parent-local local vertex using `fromExitRef`.
+If a component is modeled as a child journey, keep the full pattern coherent: parent `CompositeState`; exactly one `subjourneyId`; no child states in parent `stateRefs`; child states and transitions stay in child journey; child traversal starts from a parent transition's `toEntryRef`, otherwise from the child journey's `defaultEntryRef` when one exists, otherwise the child entry remains unresolved by Graph and must be resolved externally by materialization or execution context; exported outcome is a child-local terminal `JourneyExit` listed in child `exitRefs`; parent continuation is a parent-local `Transition` from the `CompositeState` to another parent-local local vertex using `fromExitRef`.
 
 Either keep the complete child-journey pattern or fold it back into same-journey states. Do not keep only part of the pattern.
 
@@ -130,9 +130,9 @@ For a page-level index, list page, surface, journey, or component `JourneyEntry`
 
 Use `Journey` for local traversable topology.
 
-A `Journey` must have an IRI `@id`, exactly one `defaultEntryRef`, at least one `entryRefs` value, and at least one `stateRefs` value. It may have `transitionRefs`, `exitRefs`, and `outgoingTransitionGroupRefs`. Its local vertices are `stateRefs` union `exitRefs`.
+A `Journey` must have an IRI `@id`, at least one `entryRefs` value, and at least one `stateRefs` value. It may have at most one `defaultEntryRef`, plus `transitionRefs`, `exitRefs`, and `outgoingTransitionGroupRefs`. Its local vertices are `stateRefs` union `exitRefs`.
 
-Each `entryRefs` value must reference a `JourneyEntry`. The `defaultEntryRef` must reference one of those entries.
+Each `entryRefs` value must reference a `JourneyEntry`. When present, the `defaultEntryRef` must reference one of those entries. Do not infer a default entry from `entryRefs` ordering. Graph does not define predicates, application-state expressions, domain-state mappings, or evaluation rules for contextual entry resolution.
 
 A `JourneyEntry` must have exactly one `stateRef` pointing to a `State` or `CompositeState` listed in the same journey's `stateRefs`. A `JourneyEntry` is not a local vertex and must not be used as `Transition.from` or `Transition.to`.
 
@@ -178,9 +178,9 @@ Do not reference child states from a parent transition. Do not create parent tra
 
 ## JourneyEntry, JourneyExit, and boundary refs
 
-Use `JourneyEntry` to name valid entry points into a journey. Top-level traversal begins at `defaultEntryRef.stateRef`.
+Use `JourneyEntry` to name valid entry points into a journey. Top-level traversal begins at an explicitly selected `JourneyEntry`; otherwise at `defaultEntryRef.stateRef` when a default exists; otherwise entry selection remains unresolved by Graph and must be resolved externally by materialization or execution context.
 
-Use `toEntryRef` only on a parent-local transition whose `to` is the corresponding `CompositeState`. The `toEntryRef` value selects a `JourneyEntry` listed in the child journey referenced by that composite's `subjourneyId`. If `toEntryRef` is absent, child traversal starts at the child journey's `defaultEntryRef`.
+Use `toEntryRef` only on a parent-local transition whose `to` is the corresponding `CompositeState`. The `toEntryRef` value selects a `JourneyEntry` listed in the child journey referenced by that composite's `subjourneyId`. If `toEntryRef` is absent, child traversal starts at the child journey's `defaultEntryRef` when one exists. If neither exists, Graph leaves the child entry unresolved; do not infer a default from `entryRefs` ordering.
 
 Use `JourneyExit` only when a parent journey must react to a completed child outcome, or when a journey needs to expose a terminal completion contract.
 
@@ -332,7 +332,7 @@ When generating JSON-LD:
 3. Provide a short self-audit.
 4. State uncertainty explicitly.
 
-Before returning JSON-LD, check: only necessary contexts; all nodes top-level; defined terms only; `JourneyEntryIndex` not traversable; `JourneyEntryIndex.entryRefs` reference `JourneyEntry` contracts; `Journey` only local topology; each `Journey` has `defaultEntryRef`, `entryRefs`, and `stateRefs`; each `JourneyEntry.stateRef` is in the same journey's `stateRefs`; transition endpoints local; `Transition.from` in `stateRefs`; `Transition.to` in `stateRefs` or `exitRefs`; no child states in parent transitions; each `CompositeState` has one `subjourneyId`; forms not child journeys by default; `toEntryRef` targets a child journey entry; child exits complete when used; `fromExitRef` parent-local; no fake root/parent exits; outgoing navigation uses `OutgoingTransition`; shared navigation uses `OutgoingTransitionGroup`; each outgoing transition has exactly one of `to` or `toCurrentState: true`; state-scoped `outgoingTransitionRefs` only on ordinary `State`; l10n terms only with Localization context; `copyRef`, artifact `nameRef`, and Observability accessible refs point to `MessageMeta`; each `Message` has one `messageMetaRef`, one `localeRef`, and one `value`; `Message.value` is opaque Localization data; runtime facts not in Graph; Observability absence uses `expectedMatchCount: 0` on `ObservationBinding` with locators; standard keyboard/pointer modalities use `observability:keyboard` and `observability:pointer`; Entry Binding, Effect, Condition, and Artifact do not create hidden graph edges; entry-binding `value` is opaque and not platform-typed; artifact `nameRef` and touchpoint refs stay on `Artifact`; Surface experience and Experience Annotation annotations do not affect traversal; graph is shallowest valid model.
+Before returning JSON-LD, check: only necessary contexts; all nodes top-level; defined terms only; `JourneyEntryIndex` not traversable; `JourneyEntryIndex.entryRefs` reference `JourneyEntry` contracts; `Journey` only local topology; each `Journey` has `entryRefs` and `stateRefs`; any `defaultEntryRef` references one of the same journey's `entryRefs`; no default is inferred from `entryRefs` ordering; each `JourneyEntry.stateRef` is in the same journey's `stateRefs`; transition endpoints local; `Transition.from` in `stateRefs`; `Transition.to` in `stateRefs` or `exitRefs`; no child states in parent transitions; each `CompositeState` has one `subjourneyId`; forms not child journeys by default; `toEntryRef` targets a child journey entry; child exits complete when used; `fromExitRef` parent-local; no fake root/parent exits; outgoing navigation uses `OutgoingTransition`; shared navigation uses `OutgoingTransitionGroup`; each outgoing transition has exactly one of `to` or `toCurrentState: true`; state-scoped `outgoingTransitionRefs` only on ordinary `State`; l10n terms only with Localization context; `copyRef`, artifact `nameRef`, and Observability accessible refs point to `MessageMeta`; each `Message` has one `messageMetaRef`, one `localeRef`, and one `value`; `Message.value` is opaque Localization data; runtime facts not in Graph; Observability absence uses `expectedMatchCount: 0` on `ObservationBinding` with locators; standard keyboard/pointer modalities use `observability:keyboard` and `observability:pointer`; Entry Binding, Effect, Condition, and Artifact do not create hidden graph edges; entry-binding `value` is opaque and not platform-typed; artifact `nameRef` and touchpoint refs stay on `Artifact`; Surface experience and Experience Annotation annotations do not affect traversal; graph is shallowest valid model.
 
 ## Anti-overengineering and uncertainty
 

--- a/packages/ujg-agent-pack/codex/ujg-ed-design-system-modeling/references/package-state.json
+++ b/packages/ujg-agent-pack/codex/ujg-ed-design-system-modeling/references/package-state.json
@@ -12,7 +12,7 @@
     "name": "ujg-ed-design-system-modeling"
   },
   "sourceHash": "sha256:248600ed1312f8647b994d59da5f0df54b5de1854ee26dd4068ab5026cd16f26",
-  "specHash": "sha256:95519760a312b36f388d8ab24b810a73df4115df14f3553533e771da03b3d8ab",
+  "specHash": "sha256:f1968e47a6c4b0f3c5ec2caaad084d51d781920636c684672e4e466b01cc4055",
   "target": {
     "id": "ed",
     "label": "Editor's Draft"

--- a/packages/ujg-agent-pack/codex/ujg-ed-graph-modeling/SKILL.md
+++ b/packages/ujg-agent-pack/codex/ujg-ed-graph-modeling/SKILL.md
@@ -59,7 +59,9 @@ Prefer the shallowest valid graph.
 
 Use `JourneyEntryIndex` for catalogues, product-surface indexes, documentation indexes, or collections of known `JourneyEntry` contracts. Do not use it as a traversable journey.
 
-Use `Journey` only for local traversable topology. A journey must have an IRI `@id`, exactly one `defaultEntryRef`, at least one `entryRefs` value, and at least one `stateRefs` value. Its local vertices are `stateRefs` union `exitRefs`.
+Use `Journey` only for local traversable topology. A journey must have an IRI `@id`, at least one `entryRefs` value, and at least one `stateRefs` value. It may have at most one `defaultEntryRef`. Its local vertices are `stateRefs` union `exitRefs`.
+
+Do not infer a default entry from `entryRefs` ordering. If no entry is explicitly selected and no `defaultEntryRef` exists, entry selection remains unresolved by Graph and must be resolved externally by materialization or execution context. Graph does not define predicates, application-state expressions, domain-state mappings, or evaluation rules for contextual entry resolution.
 
 Use `JourneyEntry` for explicit journey entry contracts. Each entry must have exactly one `stateRef` that points to a `State` or `CompositeState` in the same journey's `stateRefs`. A `JourneyEntry` is not a transition endpoint.
 
@@ -67,7 +69,7 @@ Use ordinary `State` and local `Transition` for stable conditions on the same pa
 
 Use `CompositeState` only when a parent journey contains or exposes a nested journey with `subjourneyId`.
 
-Use `toEntryRef` only when a parent transition into a `CompositeState` must select a specific child `JourneyEntry`; otherwise the child journey starts at its `defaultEntryRef`.
+Use `toEntryRef` only when a parent transition into a `CompositeState` must select a specific child `JourneyEntry`. Otherwise the child journey starts at its `defaultEntryRef` when one exists. If neither `toEntryRef` nor child `defaultEntryRef` exists, the child entry remains unresolved by Graph and must be resolved externally by materialization or execution context. Do not infer a child entry from `entryRefs` ordering.
 
 Use `JourneyExit` and `fromExitRef` only for exported child outcomes that a parent genuinely reacts to. Model the child outcome as a direct terminal `JourneyExit`, not as a pseudo-state.
 

--- a/packages/ujg-agent-pack/codex/ujg-ed-graph-modeling/references/package-state.json
+++ b/packages/ujg-agent-pack/codex/ujg-ed-graph-modeling/references/package-state.json
@@ -1,5 +1,5 @@
 {
-  "artifactHash": "sha256:5fe7023b933fe457096872769170b4082305b4720a84932807dcb0edf1817eef",
+  "artifactHash": "sha256:8e087c894831e7ddcf3454496ab17c92c0db1a6399e39b6c5335c675512d87ac",
   "configHash": "sha256:7c8611d9caeae261fd8d65ff8f9b50a5ce06347dfa6d0f108e77a873d30fbf21",
   "package": {
     "id": "ujg-agent-pack",
@@ -11,8 +11,8 @@
     "moduleId": "graph",
     "name": "ujg-ed-graph-modeling"
   },
-  "sourceHash": "sha256:e3e6d9da536b1042874c7aecf404a9aeaf394188cfacc18e5946d61b8209563c",
-  "specHash": "sha256:2a70e2f7b7b361c35aad001fba857081c602f704917884d395f8c0ebebd3bdcf",
+  "sourceHash": "sha256:9968fd13057e0b8458878db6d96c1b8e3d9764beb1e9343514d2862236bcaafd",
+  "specHash": "sha256:34743b6f632ba7fdf4d9f089e6c4f1ae0d766c0e781a049034204b3d35c4fc50",
   "target": {
     "id": "ed",
     "label": "Editor's Draft"

--- a/packages/ujg-agent-pack/codex/ujg-ed-l10n-modeling/references/package-state.json
+++ b/packages/ujg-agent-pack/codex/ujg-ed-l10n-modeling/references/package-state.json
@@ -12,7 +12,7 @@
     "name": "ujg-ed-l10n-modeling"
   },
   "sourceHash": "sha256:181b800c4eaa73540184158232cc7ce44a0d59bfdc599076f0bc0d1cde5d38f5",
-  "specHash": "sha256:f7b847cc061cb853ba50b6ba180458206dc15aa615d4ecff53513d92e8a4338e",
+  "specHash": "sha256:6d30f9d315024df08526793594fae6f3ab045c60906a0e8c122206ff31931b5d",
   "target": {
     "id": "ed",
     "label": "Editor's Draft"

--- a/packages/ujg-agent-pack/codex/ujg-ed-modeling/SKILL.md
+++ b/packages/ujg-agent-pack/codex/ujg-ed-modeling/SKILL.md
@@ -113,7 +113,7 @@ Classify each modeled item before writing JSON-LD: index entry, page/surface ent
 
 Do not mix roles accidentally.
 
-If a component is modeled as a child journey, keep the full pattern coherent: parent `CompositeState`; exactly one `subjourneyId`; no child states in parent `stateRefs`; child states and transitions stay in child journey; child traversal starts at the child journey's `defaultEntryRef` unless the parent transition into the composite declares `toEntryRef`; exported outcome is a child-local terminal `JourneyExit` listed in child `exitRefs`; parent continuation is a parent-local `Transition` from the `CompositeState` to another parent-local local vertex using `fromExitRef`.
+If a component is modeled as a child journey, keep the full pattern coherent: parent `CompositeState`; exactly one `subjourneyId`; no child states in parent `stateRefs`; child states and transitions stay in child journey; child traversal starts from a parent transition's `toEntryRef`, otherwise from the child journey's `defaultEntryRef` when one exists, otherwise the child entry remains unresolved by Graph and must be resolved externally by materialization or execution context; exported outcome is a child-local terminal `JourneyExit` listed in child `exitRefs`; parent continuation is a parent-local `Transition` from the `CompositeState` to another parent-local local vertex using `fromExitRef`.
 
 Either keep the complete child-journey pattern or fold it back into same-journey states. Do not keep only part of the pattern.
 
@@ -133,9 +133,9 @@ For a page-level index, list page, surface, journey, or component `JourneyEntry`
 
 Use `Journey` for local traversable topology.
 
-A `Journey` must have an IRI `@id`, exactly one `defaultEntryRef`, at least one `entryRefs` value, and at least one `stateRefs` value. It may have `transitionRefs`, `exitRefs`, and `outgoingTransitionGroupRefs`. Its local vertices are `stateRefs` union `exitRefs`.
+A `Journey` must have an IRI `@id`, at least one `entryRefs` value, and at least one `stateRefs` value. It may have at most one `defaultEntryRef`, plus `transitionRefs`, `exitRefs`, and `outgoingTransitionGroupRefs`. Its local vertices are `stateRefs` union `exitRefs`.
 
-Each `entryRefs` value must reference a `JourneyEntry`. The `defaultEntryRef` must reference one of those entries.
+Each `entryRefs` value must reference a `JourneyEntry`. When present, the `defaultEntryRef` must reference one of those entries. Do not infer a default entry from `entryRefs` ordering. Graph does not define predicates, application-state expressions, domain-state mappings, or evaluation rules for contextual entry resolution.
 
 A `JourneyEntry` must have exactly one `stateRef` pointing to a `State` or `CompositeState` listed in the same journey's `stateRefs`. A `JourneyEntry` is not a local vertex and must not be used as `Transition.from` or `Transition.to`.
 
@@ -181,9 +181,9 @@ Do not reference child states from a parent transition. Do not create parent tra
 
 ## JourneyEntry, JourneyExit, and boundary refs
 
-Use `JourneyEntry` to name valid entry points into a journey. Top-level traversal begins at `defaultEntryRef.stateRef`.
+Use `JourneyEntry` to name valid entry points into a journey. Top-level traversal begins at an explicitly selected `JourneyEntry`; otherwise at `defaultEntryRef.stateRef` when a default exists; otherwise entry selection remains unresolved by Graph and must be resolved externally by materialization or execution context.
 
-Use `toEntryRef` only on a parent-local transition whose `to` is the corresponding `CompositeState`. The `toEntryRef` value selects a `JourneyEntry` listed in the child journey referenced by that composite's `subjourneyId`. If `toEntryRef` is absent, child traversal starts at the child journey's `defaultEntryRef`.
+Use `toEntryRef` only on a parent-local transition whose `to` is the corresponding `CompositeState`. The `toEntryRef` value selects a `JourneyEntry` listed in the child journey referenced by that composite's `subjourneyId`. If `toEntryRef` is absent, child traversal starts at the child journey's `defaultEntryRef` when one exists. If neither exists, Graph leaves the child entry unresolved; do not infer a default from `entryRefs` ordering.
 
 Use `JourneyExit` only when a parent journey must react to a completed child outcome, or when a journey needs to expose a terminal completion contract.
 
@@ -335,7 +335,7 @@ When generating JSON-LD:
 3. Provide a short self-audit.
 4. State uncertainty explicitly.
 
-Before returning JSON-LD, check: only necessary contexts; all nodes top-level; defined terms only; `JourneyEntryIndex` not traversable; `JourneyEntryIndex.entryRefs` reference `JourneyEntry` contracts; `Journey` only local topology; each `Journey` has `defaultEntryRef`, `entryRefs`, and `stateRefs`; each `JourneyEntry.stateRef` is in the same journey's `stateRefs`; transition endpoints local; `Transition.from` in `stateRefs`; `Transition.to` in `stateRefs` or `exitRefs`; no child states in parent transitions; each `CompositeState` has one `subjourneyId`; forms not child journeys by default; `toEntryRef` targets a child journey entry; child exits complete when used; `fromExitRef` parent-local; no fake root/parent exits; outgoing navigation uses `OutgoingTransition`; shared navigation uses `OutgoingTransitionGroup`; each outgoing transition has exactly one of `to` or `toCurrentState: true`; state-scoped `outgoingTransitionRefs` only on ordinary `State`; l10n terms only with Localization context; `copyRef`, artifact `nameRef`, and Observability accessible refs point to `MessageMeta`; each `Message` has one `messageMetaRef`, one `localeRef`, and one `value`; `Message.value` is opaque Localization data; runtime facts not in Graph; Observability absence uses `expectedMatchCount: 0` on `ObservationBinding` with locators; standard keyboard/pointer modalities use `observability:keyboard` and `observability:pointer`; Entry Binding, Effect, Condition, and Artifact do not create hidden graph edges; entry-binding `value` is opaque and not platform-typed; artifact `nameRef` and touchpoint refs stay on `Artifact`; Surface experience and Experience Annotation annotations do not affect traversal; graph is shallowest valid model.
+Before returning JSON-LD, check: only necessary contexts; all nodes top-level; defined terms only; `JourneyEntryIndex` not traversable; `JourneyEntryIndex.entryRefs` reference `JourneyEntry` contracts; `Journey` only local topology; each `Journey` has `entryRefs` and `stateRefs`; any `defaultEntryRef` references one of the same journey's `entryRefs`; no default is inferred from `entryRefs` ordering; each `JourneyEntry.stateRef` is in the same journey's `stateRefs`; transition endpoints local; `Transition.from` in `stateRefs`; `Transition.to` in `stateRefs` or `exitRefs`; no child states in parent transitions; each `CompositeState` has one `subjourneyId`; forms not child journeys by default; `toEntryRef` targets a child journey entry; child exits complete when used; `fromExitRef` parent-local; no fake root/parent exits; outgoing navigation uses `OutgoingTransition`; shared navigation uses `OutgoingTransitionGroup`; each outgoing transition has exactly one of `to` or `toCurrentState: true`; state-scoped `outgoingTransitionRefs` only on ordinary `State`; l10n terms only with Localization context; `copyRef`, artifact `nameRef`, and Observability accessible refs point to `MessageMeta`; each `Message` has one `messageMetaRef`, one `localeRef`, and one `value`; `Message.value` is opaque Localization data; runtime facts not in Graph; Observability absence uses `expectedMatchCount: 0` on `ObservationBinding` with locators; standard keyboard/pointer modalities use `observability:keyboard` and `observability:pointer`; Entry Binding, Effect, Condition, and Artifact do not create hidden graph edges; entry-binding `value` is opaque and not platform-typed; artifact `nameRef` and touchpoint refs stay on `Artifact`; Surface experience and Experience Annotation annotations do not affect traversal; graph is shallowest valid model.
 
 ## Anti-overengineering and uncertainty
 

--- a/packages/ujg-agent-pack/codex/ujg-ed-modeling/references/package-state.json
+++ b/packages/ujg-agent-pack/codex/ujg-ed-modeling/references/package-state.json
@@ -1,5 +1,5 @@
 {
-  "artifactHash": "sha256:088e8fed9edc58a8fd37d8c53cc56ab934a34737a14171320d646be3b3828b4b",
+  "artifactHash": "sha256:4e1b4c1a4ee7d990296c8d8a2b0d88650089c0d987d6bf21b83b3d6c27b57134",
   "configHash": "sha256:7c8611d9caeae261fd8d65ff8f9b50a5ce06347dfa6d0f108e77a873d30fbf21",
   "package": {
     "id": "ujg-agent-pack",
@@ -11,8 +11,8 @@
     "moduleId": null,
     "name": "ujg-ed-modeling"
   },
-  "sourceHash": "sha256:e61d3aa84f77860f4ae63ecdfee67cb53d5bd630033d130ffff6d41b91bf5c67",
-  "specHash": "sha256:e5d32671d7b83319ba94742988700d0340c18b65f5e8bab67ae9885663dec561",
+  "sourceHash": "sha256:ef39c419228a7e283358387a1fa10979d264be63847c347f28d827718764dccd",
+  "specHash": "sha256:09c8f9f8c21b28af9b7628ed3ce9fd5766fa4a943cc9b5dd2a63deb585b8657f",
   "target": {
     "id": "ed",
     "label": "Editor's Draft"

--- a/packages/ujg-agent-pack/codex/ujg-ed-observability-modeling/references/package-state.json
+++ b/packages/ujg-agent-pack/codex/ujg-ed-observability-modeling/references/package-state.json
@@ -12,7 +12,7 @@
     "name": "ujg-ed-observability-modeling"
   },
   "sourceHash": "sha256:5e36d2dd31d4ce3db3ade68a0baad177603d99a88f867fecd50853d9e4d36379",
-  "specHash": "sha256:e34b84b1eaa938e02a3de2443f5aa348e470e41756e0d75fc529fac6c6a8bb74",
+  "specHash": "sha256:110a70f0f6b712a82780f3658f2aec6b596ad7d56d5071945db64151849d9f13",
   "target": {
     "id": "ed",
     "label": "Editor's Draft"

--- a/packages/ujg-agent-pack/manifest.json
+++ b/packages/ujg-agent-pack/manifest.json
@@ -98,13 +98,13 @@
       "publicUrl": "https://ujg.specs.openuji.org/ed",
       "skills": [
         {
-          "artifactHash": "sha256:088e8fed9edc58a8fd37d8c53cc56ab934a34737a14171320d646be3b3828b4b",
+          "artifactHash": "sha256:4e1b4c1a4ee7d990296c8d8a2b0d88650089c0d987d6bf21b83b3d6c27b57134",
           "key": "root",
           "moduleId": null,
           "name": "ujg-ed-modeling",
           "source": "sources/ed/skills/root/skill.md",
-          "sourceHash": "sha256:e61d3aa84f77860f4ae63ecdfee67cb53d5bd630033d130ffff6d41b91bf5c67",
-          "specHash": "sha256:e5d32671d7b83319ba94742988700d0340c18b65f5e8bab67ae9885663dec561"
+          "sourceHash": "sha256:ef39c419228a7e283358387a1fa10979d264be63847c347f28d827718764dccd",
+          "specHash": "sha256:09c8f9f8c21b28af9b7628ed3ce9fd5766fa4a943cc9b5dd2a63deb585b8657f"
         },
         {
           "artifactHash": "sha256:aaac7ae10f9305f062c637200a0fcdd28ddf7a79778955c5937788be74b503fb",
@@ -116,13 +116,13 @@
           "specHash": "sha256:b558b0f60049c832173481e504a31f21553ee79144de3a377144f95034b22220"
         },
         {
-          "artifactHash": "sha256:5fe7023b933fe457096872769170b4082305b4720a84932807dcb0edf1817eef",
+          "artifactHash": "sha256:8e087c894831e7ddcf3454496ab17c92c0db1a6399e39b6c5335c675512d87ac",
           "key": "graph",
           "moduleId": "graph",
           "name": "ujg-ed-graph-modeling",
           "source": "sources/ed/skills/graph/skill.md",
-          "sourceHash": "sha256:e3e6d9da536b1042874c7aecf404a9aeaf394188cfacc18e5946d61b8209563c",
-          "specHash": "sha256:2a70e2f7b7b361c35aad001fba857081c602f704917884d395f8c0ebebd3bdcf"
+          "sourceHash": "sha256:9968fd13057e0b8458878db6d96c1b8e3d9764beb1e9343514d2862236bcaafd",
+          "specHash": "sha256:34743b6f632ba7fdf4d9f089e6c4f1ae0d766c0e781a049034204b3d35c4fc50"
         },
         {
           "artifactHash": "sha256:8d5c98268ad9809f68f85ff6d0e682b4305cd5e6e441f80c262dc8796f6dd4eb",
@@ -131,7 +131,7 @@
           "name": "ujg-ed-design-system-modeling",
           "source": "sources/ed/skills/design-system/skill.md",
           "sourceHash": "sha256:248600ed1312f8647b994d59da5f0df54b5de1854ee26dd4068ab5026cd16f26",
-          "specHash": "sha256:95519760a312b36f388d8ab24b810a73df4115df14f3553533e771da03b3d8ab"
+          "specHash": "sha256:f1968e47a6c4b0f3c5ec2caaad084d51d781920636c684672e4e466b01cc4055"
         },
         {
           "artifactHash": "sha256:392ee80122535598927457a8e26c121229ea5237a1a31d7e2399cda26d6d27cd",
@@ -140,7 +140,7 @@
           "name": "ujg-ed-l10n-modeling",
           "source": "sources/ed/skills/localization/skill.md",
           "sourceHash": "sha256:181b800c4eaa73540184158232cc7ce44a0d59bfdc599076f0bc0d1cde5d38f5",
-          "specHash": "sha256:f7b847cc061cb853ba50b6ba180458206dc15aa615d4ecff53513d92e8a4338e"
+          "specHash": "sha256:6d30f9d315024df08526793594fae6f3ab045c60906a0e8c122206ff31931b5d"
         },
         {
           "artifactHash": "sha256:e451bc4b57065b4f1d2afdcf02d266bd139874ec9d504810a7cd623b01993159",
@@ -149,7 +149,7 @@
           "name": "ujg-ed-observability-modeling",
           "source": "sources/ed/skills/observability/skill.md",
           "sourceHash": "sha256:5e36d2dd31d4ce3db3ade68a0baad177603d99a88f867fecd50853d9e4d36379",
-          "specHash": "sha256:e34b84b1eaa938e02a3de2443f5aa348e470e41756e0d75fc529fac6c6a8bb74"
+          "specHash": "sha256:110a70f0f6b712a82780f3658f2aec6b596ad7d56d5071945db64151849d9f13"
         }
       ],
       "specRoot": "specs/ed"

--- a/packages/ujg-agent-pack/reviews/ed/design-system/latest.md
+++ b/packages/ujg-agent-pack/reviews/ed/design-system/latest.md
@@ -13,7 +13,7 @@ Spec URL: https://ujg.specs.openuji.org/ed/modules/design-system
 ## Review Inputs
 
 - Source hash: sha256:248600ed1312f8647b994d59da5f0df54b5de1854ee26dd4068ab5026cd16f26
-- Spec hash: sha256:95519760a312b36f388d8ab24b810a73df4115df14f3553533e771da03b3d8ab
+- Spec hash: sha256:f1968e47a6c4b0f3c5ec2caaad084d51d781920636c684672e4e466b01cc4055
 
 ## Source Headings Likely Affected
 

--- a/packages/ujg-agent-pack/reviews/ed/graph/latest.md
+++ b/packages/ujg-agent-pack/reviews/ed/graph/latest.md
@@ -12,8 +12,8 @@ Spec URL: https://ujg.specs.openuji.org/ed/graph
 
 ## Review Inputs
 
-- Source hash: sha256:e3e6d9da536b1042874c7aecf404a9aeaf394188cfacc18e5946d61b8209563c
-- Spec hash: sha256:2a70e2f7b7b361c35aad001fba857081c602f704917884d395f8c0ebebd3bdcf
+- Source hash: sha256:9968fd13057e0b8458878db6d96c1b8e3d9764beb1e9343514d2862236bcaafd
+- Spec hash: sha256:34743b6f632ba7fdf4d9f089e6c4f1ae0d766c0e781a049034204b3d35c4fc50
 
 ## Source Headings Likely Affected
 

--- a/packages/ujg-agent-pack/reviews/ed/localization/latest.md
+++ b/packages/ujg-agent-pack/reviews/ed/localization/latest.md
@@ -13,7 +13,7 @@ Spec URL: https://ujg.specs.openuji.org/ed/modules/l10n
 ## Review Inputs
 
 - Source hash: sha256:181b800c4eaa73540184158232cc7ce44a0d59bfdc599076f0bc0d1cde5d38f5
-- Spec hash: sha256:f7b847cc061cb853ba50b6ba180458206dc15aa615d4ecff53513d92e8a4338e
+- Spec hash: sha256:6d30f9d315024df08526793594fae6f3ab045c60906a0e8c122206ff31931b5d
 
 ## Source Headings Likely Affected
 

--- a/packages/ujg-agent-pack/reviews/ed/observability/latest.md
+++ b/packages/ujg-agent-pack/reviews/ed/observability/latest.md
@@ -13,7 +13,7 @@ Spec URL: https://ujg.specs.openuji.org/ed/modules/observability
 ## Review Inputs
 
 - Source hash: sha256:5e36d2dd31d4ce3db3ade68a0baad177603d99a88f867fecd50853d9e4d36379
-- Spec hash: sha256:e34b84b1eaa938e02a3de2443f5aa348e470e41756e0d75fc529fac6c6a8bb74
+- Spec hash: sha256:110a70f0f6b712a82780f3658f2aec6b596ad7d56d5071945db64151849d9f13
 
 ## Source Headings Likely Affected
 

--- a/packages/ujg-agent-pack/reviews/ed/root/latest.md
+++ b/packages/ujg-agent-pack/reviews/ed/root/latest.md
@@ -12,8 +12,8 @@ Spec URL: https://ujg.specs.openuji.org/ed
 
 ## Review Inputs
 
-- Source hash: sha256:e61d3aa84f77860f4ae63ecdfee67cb53d5bd630033d130ffff6d41b91bf5c67
-- Spec hash: sha256:e5d32671d7b83319ba94742988700d0340c18b65f5e8bab67ae9885663dec561
+- Source hash: sha256:ef39c419228a7e283358387a1fa10979d264be63847c347f28d827718764dccd
+- Spec hash: sha256:09c8f9f8c21b28af9b7628ed3ce9fd5766fa4a943cc9b5dd2a63deb585b8657f
 
 ## Source Headings Likely Affected
 

--- a/packages/ujg-agent-pack/reviews/registry.json
+++ b/packages/ujg-agent-pack/reviews/registry.json
@@ -11,35 +11,35 @@
       "reportPath": "reviews/ed/design-system/latest.md",
       "skill": "design-system",
       "sourceHash": "sha256:248600ed1312f8647b994d59da5f0df54b5de1854ee26dd4068ab5026cd16f26",
-      "specHash": "sha256:95519760a312b36f388d8ab24b810a73df4115df14f3553533e771da03b3d8ab",
+      "specHash": "sha256:f1968e47a6c4b0f3c5ec2caaad084d51d781920636c684672e4e466b01cc4055",
       "target": "ed"
     },
     "ed/graph": {
       "reportPath": "reviews/ed/graph/latest.md",
       "skill": "graph",
-      "sourceHash": "sha256:e3e6d9da536b1042874c7aecf404a9aeaf394188cfacc18e5946d61b8209563c",
-      "specHash": "sha256:2a70e2f7b7b361c35aad001fba857081c602f704917884d395f8c0ebebd3bdcf",
+      "sourceHash": "sha256:9968fd13057e0b8458878db6d96c1b8e3d9764beb1e9343514d2862236bcaafd",
+      "specHash": "sha256:34743b6f632ba7fdf4d9f089e6c4f1ae0d766c0e781a049034204b3d35c4fc50",
       "target": "ed"
     },
     "ed/localization": {
       "reportPath": "reviews/ed/localization/latest.md",
       "skill": "localization",
       "sourceHash": "sha256:181b800c4eaa73540184158232cc7ce44a0d59bfdc599076f0bc0d1cde5d38f5",
-      "specHash": "sha256:f7b847cc061cb853ba50b6ba180458206dc15aa615d4ecff53513d92e8a4338e",
+      "specHash": "sha256:6d30f9d315024df08526793594fae6f3ab045c60906a0e8c122206ff31931b5d",
       "target": "ed"
     },
     "ed/observability": {
       "reportPath": "reviews/ed/observability/latest.md",
       "skill": "observability",
       "sourceHash": "sha256:5e36d2dd31d4ce3db3ade68a0baad177603d99a88f867fecd50853d9e4d36379",
-      "specHash": "sha256:e34b84b1eaa938e02a3de2443f5aa348e470e41756e0d75fc529fac6c6a8bb74",
+      "specHash": "sha256:110a70f0f6b712a82780f3658f2aec6b596ad7d56d5071945db64151849d9f13",
       "target": "ed"
     },
     "ed/root": {
       "reportPath": "reviews/ed/root/latest.md",
       "skill": "root",
-      "sourceHash": "sha256:e61d3aa84f77860f4ae63ecdfee67cb53d5bd630033d130ffff6d41b91bf5c67",
-      "specHash": "sha256:e5d32671d7b83319ba94742988700d0340c18b65f5e8bab67ae9885663dec561",
+      "sourceHash": "sha256:ef39c419228a7e283358387a1fa10979d264be63847c347f28d827718764dccd",
+      "specHash": "sha256:09c8f9f8c21b28af9b7628ed3ce9fd5766fa4a943cc9b5dd2a63deb585b8657f",
       "target": "ed"
     },
     "tr/1.0-rc1/core": {

--- a/packages/ujg-agent-pack/sources/ed/skills/graph/skill.md
+++ b/packages/ujg-agent-pack/sources/ed/skills/graph/skill.md
@@ -33,7 +33,9 @@ Prefer the shallowest valid graph.
 
 Use `JourneyEntryIndex` for catalogues, product-surface indexes, documentation indexes, or collections of known `JourneyEntry` contracts. Do not use it as a traversable journey.
 
-Use `Journey` only for local traversable topology. A journey must have an IRI `@id`, exactly one `defaultEntryRef`, at least one `entryRefs` value, and at least one `stateRefs` value. Its local vertices are `stateRefs` union `exitRefs`.
+Use `Journey` only for local traversable topology. A journey must have an IRI `@id`, at least one `entryRefs` value, and at least one `stateRefs` value. It may have at most one `defaultEntryRef`. Its local vertices are `stateRefs` union `exitRefs`.
+
+Do not infer a default entry from `entryRefs` ordering. If no entry is explicitly selected and no `defaultEntryRef` exists, entry selection remains unresolved by Graph and must be resolved externally by materialization or execution context. Graph does not define predicates, application-state expressions, domain-state mappings, or evaluation rules for contextual entry resolution.
 
 Use `JourneyEntry` for explicit journey entry contracts. Each entry must have exactly one `stateRef` that points to a `State` or `CompositeState` in the same journey's `stateRefs`. A `JourneyEntry` is not a transition endpoint.
 
@@ -41,7 +43,7 @@ Use ordinary `State` and local `Transition` for stable conditions on the same pa
 
 Use `CompositeState` only when a parent journey contains or exposes a nested journey with `subjourneyId`.
 
-Use `toEntryRef` only when a parent transition into a `CompositeState` must select a specific child `JourneyEntry`; otherwise the child journey starts at its `defaultEntryRef`.
+Use `toEntryRef` only when a parent transition into a `CompositeState` must select a specific child `JourneyEntry`. Otherwise the child journey starts at its `defaultEntryRef` when one exists. If neither `toEntryRef` nor child `defaultEntryRef` exists, the child entry remains unresolved by Graph and must be resolved externally by materialization or execution context. Do not infer a child entry from `entryRefs` ordering.
 
 Use `JourneyExit` and `fromExitRef` only for exported child outcomes that a parent genuinely reacts to. Model the child outcome as a direct terminal `JourneyExit`, not as a pseudo-state.
 

--- a/packages/ujg-agent-pack/sources/ed/skills/root/skill.md
+++ b/packages/ujg-agent-pack/sources/ed/skills/root/skill.md
@@ -87,7 +87,7 @@ Classify each modeled item before writing JSON-LD: index entry, page/surface ent
 
 Do not mix roles accidentally.
 
-If a component is modeled as a child journey, keep the full pattern coherent: parent `CompositeState`; exactly one `subjourneyId`; no child states in parent `stateRefs`; child states and transitions stay in child journey; child traversal starts at the child journey's `defaultEntryRef` unless the parent transition into the composite declares `toEntryRef`; exported outcome is a child-local terminal `JourneyExit` listed in child `exitRefs`; parent continuation is a parent-local `Transition` from the `CompositeState` to another parent-local local vertex using `fromExitRef`.
+If a component is modeled as a child journey, keep the full pattern coherent: parent `CompositeState`; exactly one `subjourneyId`; no child states in parent `stateRefs`; child states and transitions stay in child journey; child traversal starts from a parent transition's `toEntryRef`, otherwise from the child journey's `defaultEntryRef` when one exists, otherwise the child entry remains unresolved by Graph and must be resolved externally by materialization or execution context; exported outcome is a child-local terminal `JourneyExit` listed in child `exitRefs`; parent continuation is a parent-local `Transition` from the `CompositeState` to another parent-local local vertex using `fromExitRef`.
 
 Either keep the complete child-journey pattern or fold it back into same-journey states. Do not keep only part of the pattern.
 
@@ -107,9 +107,9 @@ For a page-level index, list page, surface, journey, or component `JourneyEntry`
 
 Use `Journey` for local traversable topology.
 
-A `Journey` must have an IRI `@id`, exactly one `defaultEntryRef`, at least one `entryRefs` value, and at least one `stateRefs` value. It may have `transitionRefs`, `exitRefs`, and `outgoingTransitionGroupRefs`. Its local vertices are `stateRefs` union `exitRefs`.
+A `Journey` must have an IRI `@id`, at least one `entryRefs` value, and at least one `stateRefs` value. It may have at most one `defaultEntryRef`, plus `transitionRefs`, `exitRefs`, and `outgoingTransitionGroupRefs`. Its local vertices are `stateRefs` union `exitRefs`.
 
-Each `entryRefs` value must reference a `JourneyEntry`. The `defaultEntryRef` must reference one of those entries.
+Each `entryRefs` value must reference a `JourneyEntry`. When present, the `defaultEntryRef` must reference one of those entries. Do not infer a default entry from `entryRefs` ordering. Graph does not define predicates, application-state expressions, domain-state mappings, or evaluation rules for contextual entry resolution.
 
 A `JourneyEntry` must have exactly one `stateRef` pointing to a `State` or `CompositeState` listed in the same journey's `stateRefs`. A `JourneyEntry` is not a local vertex and must not be used as `Transition.from` or `Transition.to`.
 
@@ -155,9 +155,9 @@ Do not reference child states from a parent transition. Do not create parent tra
 
 ## JourneyEntry, JourneyExit, and boundary refs
 
-Use `JourneyEntry` to name valid entry points into a journey. Top-level traversal begins at `defaultEntryRef.stateRef`.
+Use `JourneyEntry` to name valid entry points into a journey. Top-level traversal begins at an explicitly selected `JourneyEntry`; otherwise at `defaultEntryRef.stateRef` when a default exists; otherwise entry selection remains unresolved by Graph and must be resolved externally by materialization or execution context.
 
-Use `toEntryRef` only on a parent-local transition whose `to` is the corresponding `CompositeState`. The `toEntryRef` value selects a `JourneyEntry` listed in the child journey referenced by that composite's `subjourneyId`. If `toEntryRef` is absent, child traversal starts at the child journey's `defaultEntryRef`.
+Use `toEntryRef` only on a parent-local transition whose `to` is the corresponding `CompositeState`. The `toEntryRef` value selects a `JourneyEntry` listed in the child journey referenced by that composite's `subjourneyId`. If `toEntryRef` is absent, child traversal starts at the child journey's `defaultEntryRef` when one exists. If neither exists, Graph leaves the child entry unresolved; do not infer a default from `entryRefs` ordering.
 
 Use `JourneyExit` only when a parent journey must react to a completed child outcome, or when a journey needs to expose a terminal completion contract.
 
@@ -309,7 +309,7 @@ When generating JSON-LD:
 3. Provide a short self-audit.
 4. State uncertainty explicitly.
 
-Before returning JSON-LD, check: only necessary contexts; all nodes top-level; defined terms only; `JourneyEntryIndex` not traversable; `JourneyEntryIndex.entryRefs` reference `JourneyEntry` contracts; `Journey` only local topology; each `Journey` has `defaultEntryRef`, `entryRefs`, and `stateRefs`; each `JourneyEntry.stateRef` is in the same journey's `stateRefs`; transition endpoints local; `Transition.from` in `stateRefs`; `Transition.to` in `stateRefs` or `exitRefs`; no child states in parent transitions; each `CompositeState` has one `subjourneyId`; forms not child journeys by default; `toEntryRef` targets a child journey entry; child exits complete when used; `fromExitRef` parent-local; no fake root/parent exits; outgoing navigation uses `OutgoingTransition`; shared navigation uses `OutgoingTransitionGroup`; each outgoing transition has exactly one of `to` or `toCurrentState: true`; state-scoped `outgoingTransitionRefs` only on ordinary `State`; l10n terms only with Localization context; `copyRef`, artifact `nameRef`, and Observability accessible refs point to `MessageMeta`; each `Message` has one `messageMetaRef`, one `localeRef`, and one `value`; `Message.value` is opaque Localization data; runtime facts not in Graph; Observability absence uses `expectedMatchCount: 0` on `ObservationBinding` with locators; standard keyboard/pointer modalities use `observability:keyboard` and `observability:pointer`; Entry Binding, Effect, Condition, and Artifact do not create hidden graph edges; entry-binding `value` is opaque and not platform-typed; artifact `nameRef` and touchpoint refs stay on `Artifact`; Surface experience and Experience Annotation annotations do not affect traversal; graph is shallowest valid model.
+Before returning JSON-LD, check: only necessary contexts; all nodes top-level; defined terms only; `JourneyEntryIndex` not traversable; `JourneyEntryIndex.entryRefs` reference `JourneyEntry` contracts; `Journey` only local topology; each `Journey` has `entryRefs` and `stateRefs`; any `defaultEntryRef` references one of the same journey's `entryRefs`; no default is inferred from `entryRefs` ordering; each `JourneyEntry.stateRef` is in the same journey's `stateRefs`; transition endpoints local; `Transition.from` in `stateRefs`; `Transition.to` in `stateRefs` or `exitRefs`; no child states in parent transitions; each `CompositeState` has one `subjourneyId`; forms not child journeys by default; `toEntryRef` targets a child journey entry; child exits complete when used; `fromExitRef` parent-local; no fake root/parent exits; outgoing navigation uses `OutgoingTransition`; shared navigation uses `OutgoingTransitionGroup`; each outgoing transition has exactly one of `to` or `toCurrentState: true`; state-scoped `outgoingTransitionRefs` only on ordinary `State`; l10n terms only with Localization context; `copyRef`, artifact `nameRef`, and Observability accessible refs point to `MessageMeta`; each `Message` has one `messageMetaRef`, one `localeRef`, and one `value`; `Message.value` is opaque Localization data; runtime facts not in Graph; Observability absence uses `expectedMatchCount: 0` on `ObservationBinding` with locators; standard keyboard/pointer modalities use `observability:keyboard` and `observability:pointer`; Entry Binding, Effect, Condition, and Artifact do not create hidden graph edges; entry-binding `value` is opaque and not platform-typed; artifact `nameRef` and touchpoint refs stay on `Artifact`; Surface experience and Experience Annotation annotations do not affect traversal; graph is shallowest valid model.
 
 ## Anti-overengineering and uncertainty
 

--- a/specs/ed/graph/content-manifest.json
+++ b/specs/ed/graph/content-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
   "publishedAt": "2026-02-14T16:41:32.000Z",
-  "updatedAt": "2026-07-23T16:45:41.723Z",
-  "contentHash": "sha256:17f747b3af3fcc8dd49e3f582bf5a2d95aa08b80ffa4531e9c880261e255b4af"
+  "updatedAt": "2026-08-21T12:26:36.741Z",
+  "contentHash": "sha256:f1be4217d8892885f1788ea78102c4e43a24c2e80ba6cdbc6e801817c59ee332"
 }

--- a/specs/ed/graph/graph.shape.ttl
+++ b/specs/ed/graph/graph.shape.ttl
@@ -32,7 +32,6 @@ ujggraphshape:JourneyShape a sh:NodeShape ;
 
   sh:property [
     sh:path ujggraph:defaultEntryRef ;
-    sh:minCount 1 ;
     sh:maxCount 1 ;
     sh:class ujggraph:JourneyEntry ;
     sh:nodeKind sh:IRI ;

--- a/specs/ed/graph/graph.ttl
+++ b/specs/ed/graph/graph.ttl
@@ -65,7 +65,7 @@ ujggraph:defaultEntryRef a owl:ObjectProperty ;
   rdfs:domain ujggraph:Journey ;
   rdfs:range ujggraph:JourneyEntry ;
   rdfs:label "default entry ref" ;
-  rdfs:comment "References the JourneyEntry used when traversal starts without a more specific entry selection." .
+  rdfs:comment "References the JourneyEntry used, when declared, if traversal starts without a more specific entry selection." .
 
 ujggraph:entryRefs a owl:ObjectProperty ;
   rdfs:range ujggraph:JourneyEntry ;

--- a/specs/ed/graph/index.md
+++ b/specs/ed/graph/index.md
@@ -144,8 +144,8 @@ Use [=Journey=] when the modeled object owns local traversal, progression, or st
 <spec-statement>
 1. A [=Journey=] **MUST** be identified by an IRI.
 2. A [=Journey=] **MUST** declare at least one `entryRefs` value.
-3. A [=Journey=] **MUST** declare exactly one `defaultEntryRef`.
-4. The `defaultEntryRef` value **MUST** be listed in the same [=Journey=]'s `entryRefs`.
+3. A [=Journey=] **MAY** declare at most one `defaultEntryRef`.
+4. If present, the `defaultEntryRef` value **MUST** be listed in the same [=Journey=]'s `entryRefs`.
 5. A [=Journey=] **MUST** declare at least one `stateRefs` value.
 6. A [=Journey=] **MAY** declare `transitionRefs`.
 7. A [=Journey=] **MAY** declare `exitRefs`.
@@ -258,6 +258,48 @@ A single-state journey can omit `transitionRefs`:
 ]
 ```
 
+A journey can also omit `defaultEntryRef` when no entry is semantically a general fallback. In that
+case, entry selection is unresolved by Graph unless an execution or materialization context selects
+exactly one listed [=JourneyEntry=].
+
+```json
+[
+  {
+    "@type": "Journey",
+    "@id": "urn:ujg:journey:workshop-detail",
+    "label": "Workshop detail",
+    "entryRefs": [
+      "urn:ujg:entry:workshop-registration-open",
+      "urn:ujg:entry:workshop-waitlist-open",
+      "urn:ujg:entry:workshop-registration-closed"
+    ],
+    "stateRefs": [
+      "urn:ujg:state:workshop-registration-open",
+      "urn:ujg:state:workshop-waitlist-open",
+      "urn:ujg:state:workshop-registration-closed"
+    ]
+  },
+  {
+    "@type": "JourneyEntry",
+    "@id": "urn:ujg:entry:workshop-registration-open",
+    "label": "Registration open",
+    "stateRef": "urn:ujg:state:workshop-registration-open"
+  },
+  {
+    "@type": "JourneyEntry",
+    "@id": "urn:ujg:entry:workshop-waitlist-open",
+    "label": "Waitlist open",
+    "stateRef": "urn:ujg:state:workshop-waitlist-open"
+  },
+  {
+    "@type": "JourneyEntry",
+    "@id": "urn:ujg:entry:workshop-registration-closed",
+    "label": "Registration closed",
+    "stateRef": "urn:ujg:state:workshop-registration-closed"
+  }
+]
+```
+
 ---
 
 ## JourneyEntry {data-cop-concept="journey-entry"}
@@ -276,7 +318,24 @@ A [=JourneyEntry=] is an explicit entry contract for a [=Journey=]. It identifie
 9. A [=JourneyEntry=] **MAY** declare one or more `tags`.
 </spec-statement>
 
-Top-level execution of a [=Journey=] begins at the `stateRef` of the [=Journey=]'s `defaultEntryRef`. Child journey execution can select a more specific entry through a parent transition's `toEntryRef`; otherwise it also begins at the child journey's `defaultEntryRef`.
+Top-level traversal of a [=Journey=] begins at an explicitly selected [=JourneyEntry=]. If no
+entry is explicitly selected and the [=Journey=] declares `defaultEntryRef`, traversal begins at
+the `stateRef` of that default entry. If neither applies, entry selection remains unresolved by
+Graph.
+
+A materialization or execution context **MAY** resolve exactly one of the [=Journey=]'s `entryRefs`
+when Graph leaves entry selection unresolved. Graph does not define the criteria by which such
+contextual entry resolution occurs.
+
+A Consumer **MUST NOT** infer a contextually resolved entry from `entryRefs` ordering. Absence of
+`defaultEntryRef` **MUST NOT** imply that the first `entryRefs` value is the default. Contextual
+entry resolution **MUST NOT** alter Graph topology. Graph **MUST NOT** define predicates,
+application-state expressions, domain-state mappings, or evaluation rules for contextual entry
+resolution.
+
+If no entry has been explicitly selected, no `defaultEntryRef` exists, and the current
+materialization or execution context cannot resolve exactly one entry, traversal into that
+[=Journey=] is unresolved. An unresolved entry selection does not make the Graph invalid.
 
 ```mermaid
 classDiagram
@@ -550,7 +609,17 @@ When a Consumer enters a [=CompositeState=], it **MAY** resolve the composite st
 
 If the parent transition whose `to` value enters the [=CompositeState=] declares `toEntryRef`, child traversal begins at the `stateRef` of that [=JourneyEntry=].
 
-If the parent transition does not declare `toEntryRef`, child traversal begins at the `stateRef` of the child [=Journey=]'s `defaultEntryRef`.
+Otherwise, if the child [=Journey=] declares `defaultEntryRef`, child traversal begins at the
+`stateRef` of that default entry.
+
+Otherwise, the child [=Journey=]'s entry selection remains unresolved by Graph. A materialization or
+execution context **MAY** resolve exactly one of the child [=Journey=]'s `entryRefs`.
+
+If no `toEntryRef` exists, no child `defaultEntryRef` exists, and the current materialization or
+execution context cannot resolve exactly one child entry, traversal into that child [=Journey=] is
+unresolved. An unresolved child entry selection does not make the Graph invalid. A Consumer
+**MUST NOT** infer a child entry from `entryRefs` ordering or treat the first `entryRefs` value as a
+default.
 
 If interpretation of the child journey reaches a [=JourneyExit=] listed in that child journey's `exitRefs`, that [=JourneyExit=] becomes the exported exit of the child journey.
 
@@ -570,7 +639,10 @@ A Consumer **MUST NOT** treat `toEntryRef` or `fromExitRef` as a replacement for
 A Consumer **MUST NOT** treat a parent transition without `fromExitRef` as a fallback for an exported child journey exit.
 </spec-statement>
 
-Use `toEntryRef` when a parent transition must choose a specific child entry other than the child journey's default entry. Use [=JourneyExit=] and `fromExitRef` when a nested journey has multiple explicit child outcomes that the parent journey needs to distinguish. Do not use [=JourneyExit=] for ordinary transitions inside the child journey; use normal child [=Transition=] resources for internal child movement.
+Use `toEntryRef` when a parent transition must choose a specific child entry. Use [=JourneyExit=]
+and `fromExitRef` when a nested journey has multiple explicit child outcomes that the parent
+journey needs to distinguish. Do not use [=JourneyExit=] for ordinary transitions inside the child
+journey; use normal child [=Transition=] resources for internal child movement.
 
 ```mermaid
 classDiagram

--- a/specs/ed/modules/entry-binding/content-manifest.json
+++ b/specs/ed/modules/entry-binding/content-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
   "publishedAt": "2026-07-23T00:00:00.000Z",
-  "updatedAt": "2026-07-28T11:39:49.564Z",
-  "contentHash": "sha256:d306b33b7d7ea748ebfb14f713ccbc896f546316b866afe49735697041d88ce8"
+  "updatedAt": "2026-08-21T12:26:36.741Z",
+  "contentHash": "sha256:c2fb5d8387701dfb463da40c4e15595b53795c7d0367e603a940e53c08687f27"
 }

--- a/specs/ed/modules/entry-binding/index.md
+++ b/specs/ed/modules/entry-binding/index.md
@@ -48,6 +48,10 @@ The module introduces real JSON-LD terms and RDF edges for entry binding:
 `EntryBinding` does not declare a touchpoint, materialization discriminator, fallback target,
 structured invocation fields, or execution rule.
 
+If an `EntryBinding` references a [=JourneyEntry=] whose `stateRef` points to a
+[=CompositeState=], the binding selects only that outer entry. It does not select an entry of the
+composite state's child [=Journey=].
+
 ## Normative Artifacts
 
 This module is published through the following artifacts:


### PR DESCRIPTION
## Summary

- Make `Journey.defaultEntryRef` optional in the Editor’s Draft Graph module.
- Define entry resolution separately from topology: explicit `toEntryRef`, optional `defaultEntryRef`, then external contextual resolution.
- Clarify that unresolved entry selection does not make a Graph invalid and must not be inferred from `entryRefs` ordering.
- Regenerate ED agent-pack guidance, package metadata, reviews, and content manifests.

## Validation

- `pnpm content-manifests:check`
- `pnpm agent-pack:check`
- `pnpm agent-pack:validate`
- `pnpm --filter @openuji/web exec speculator-lint ujg.workspace.json`