### PR TITLE
respec Design System node

### DIFF
--- a/packages/ujg-agent-pack/agents/ed/design-system/AGENTS.md
+++ b/packages/ujg-agent-pack/agents/ed/design-system/AGENTS.md
@@ -36,7 +36,7 @@ Correct layer order:
 ```text
 Surface -> graphNodeRef -> supported Graph node
 SurfaceRealization -> surfaceRef + componentRef/templateRef
-DesignSystem -> componentRefs/templateRefs/tokenSourceRefs/surfaceRealizationRefs
+DesignSystem -> tokenSourceRefs
 ```
 
 Graph defines topology.
@@ -73,9 +73,6 @@ Use only these common Design System properties:
 
 ```text
 tokenSourceRefs
-componentRefs
-templateRefs
-surfaceRealizationRefs
 surfaceRef
 componentRef
 templateRef
@@ -185,6 +182,14 @@ Slot bindings are presentation composition only. They do not imply traversal, st
 Use `TokenSource` only to reference a token source, package, manifest, or token set.
 
 Do not encode token values, CSS variables, aliases, themes, or style calculations unless the user explicitly asks for a project extension.
+
+## DesignSystem
+
+Use `DesignSystem` only as a token-source scope through `tokenSourceRefs`.
+
+Do not use `DesignSystem` as a component registry, template registry, or surface-realization registry.
+
+Consumers derive component, template, and realization inventories from `Component`, `Template`, `SurfaceRealization`, and `SlotBinding` nodes directly.
 
 ## Navigation and forms
 

--- a/packages/ujg-agent-pack/codex/ujg-ed-design-system-modeling/SKILL.md
+++ b/packages/ujg-agent-pack/codex/ujg-ed-design-system-modeling/SKILL.md
@@ -39,7 +39,7 @@ Correct layer order:
 ```text
 Surface -> graphNodeRef -> supported Graph node
 SurfaceRealization -> surfaceRef + componentRef/templateRef
-DesignSystem -> componentRefs/templateRefs/tokenSourceRefs/surfaceRealizationRefs
+DesignSystem -> tokenSourceRefs
 ```
 
 Graph defines topology.
@@ -76,9 +76,6 @@ Use only these common Design System properties:
 
 ```text
 tokenSourceRefs
-componentRefs
-templateRefs
-surfaceRealizationRefs
 surfaceRef
 componentRef
 templateRef
@@ -188,6 +185,14 @@ Slot bindings are presentation composition only. They do not imply traversal, st
 Use `TokenSource` only to reference a token source, package, manifest, or token set.
 
 Do not encode token values, CSS variables, aliases, themes, or style calculations unless the user explicitly asks for a project extension.
+
+## DesignSystem
+
+Use `DesignSystem` only as a token-source scope through `tokenSourceRefs`.
+
+Do not use `DesignSystem` as a component registry, template registry, or surface-realization registry.
+
+Consumers derive component, template, and realization inventories from `Component`, `Template`, `SurfaceRealization`, and `SlotBinding` nodes directly.
 
 ## Navigation and forms
 

--- a/packages/ujg-agent-pack/codex/ujg-ed-design-system-modeling/references/package-state.json
+++ b/packages/ujg-agent-pack/codex/ujg-ed-design-system-modeling/references/package-state.json
@@ -1,5 +1,5 @@
 {
-  "artifactHash": "sha256:a88db1d05ebba48b7babbd5636046034dec4764796ab839cb39d2a79a0b086fb",
+  "artifactHash": "sha256:5ac572391140a68205f927f430fe34b5f65268f9778f5ff06b62e70b2610ce85",
   "configHash": "sha256:30f42af0249b06e058e91e4a9e1eb285c7bd13a15dd567bebf489387d9454585",
   "package": {
     "id": "ujg-agent-pack",
@@ -11,8 +11,8 @@
     "moduleId": "modules/design-system",
     "name": "ujg-ed-design-system-modeling"
   },
-  "sourceHash": "sha256:248600ed1312f8647b994d59da5f0df54b5de1854ee26dd4068ab5026cd16f26",
-  "specHash": "sha256:cf50c5a831f35de643ef910113c55e78235ca798b307fdc5db1a205dba6fe6d7",
+  "sourceHash": "sha256:32f4beea7ad532deeb88098f2d738ed150a2b547820d00afa1916e96a8de8474",
+  "specHash": "sha256:f6b77a460867aa9c3ff73e03026c33db58a03a1f38437054bd34f9aadef2d049",
   "target": {
     "id": "ed",
     "label": "Editor's Draft"

--- a/packages/ujg-agent-pack/codex/ujg-ed-domain-model-design/references/package-state.json
+++ b/packages/ujg-agent-pack/codex/ujg-ed-domain-model-design/references/package-state.json
@@ -12,7 +12,7 @@
     "name": "ujg-ed-domain-model-design"
   },
   "sourceHash": "sha256:50eb75c2ad144259b7214e685e1b63606de6494198c27677fd9876373f2de956",
-  "specHash": "sha256:75c85eef3dd0201ad6d4fd2bc3738a00742451d6473337e2f6bde5ee2e81439e",
+  "specHash": "sha256:dff462241bc64427b2692e124d85e8b3050bd16e5c78f3cc8832a27966383be9",
   "target": {
     "id": "ed",
     "label": "Editor's Draft"

--- a/packages/ujg-agent-pack/codex/ujg-ed-domain-model-evaluation/references/package-state.json
+++ b/packages/ujg-agent-pack/codex/ujg-ed-domain-model-evaluation/references/package-state.json
@@ -12,7 +12,7 @@
     "name": "ujg-ed-domain-model-evaluation"
   },
   "sourceHash": "sha256:ddbf680434d50519aaff77a1788d7e55c6580e5d852abdd2d924787b8f3ec3b1",
-  "specHash": "sha256:75c85eef3dd0201ad6d4fd2bc3738a00742451d6473337e2f6bde5ee2e81439e",
+  "specHash": "sha256:dff462241bc64427b2692e124d85e8b3050bd16e5c78f3cc8832a27966383be9",
   "target": {
     "id": "ed",
     "label": "Editor's Draft"

--- a/packages/ujg-agent-pack/codex/ujg-ed-modeling/references/package-state.json
+++ b/packages/ujg-agent-pack/codex/ujg-ed-modeling/references/package-state.json
@@ -12,7 +12,7 @@
     "name": "ujg-ed-modeling"
   },
   "sourceHash": "sha256:a70767c9f833acd3c26b0999e5934241279d2e28f30c858ca54def64da54b470",
-  "specHash": "sha256:10d99802f110e6cf79bc67a11031bb4884c8717afc74bab621be640c01cd699c",
+  "specHash": "sha256:0a850d13e5dce200b6aec3d452b08dbf6fcae3af6eb98c9719168f1b1a170d7f",
   "target": {
     "id": "ed",
     "label": "Editor's Draft"

--- a/packages/ujg-agent-pack/manifest.json
+++ b/packages/ujg-agent-pack/manifest.json
@@ -116,7 +116,7 @@
           "name": "ujg-ed-modeling",
           "source": "sources/ed/skills/root/skill.md",
           "sourceHash": "sha256:a70767c9f833acd3c26b0999e5934241279d2e28f30c858ca54def64da54b470",
-          "specHash": "sha256:10d99802f110e6cf79bc67a11031bb4884c8717afc74bab621be640c01cd699c"
+          "specHash": "sha256:0a850d13e5dce200b6aec3d452b08dbf6fcae3af6eb98c9719168f1b1a170d7f"
         },
         {
           "artifactHash": "sha256:60ff1ba8a30879af3ecf7e692a91112468f29122e495ae1cf875abeb5e9f1c0b",
@@ -137,13 +137,13 @@
           "specHash": "sha256:13b372c211e423c09a97155a24e8d0aca3f172620cd463f9d0e842d5f9173a45"
         },
         {
-          "artifactHash": "sha256:a88db1d05ebba48b7babbd5636046034dec4764796ab839cb39d2a79a0b086fb",
+          "artifactHash": "sha256:5ac572391140a68205f927f430fe34b5f65268f9778f5ff06b62e70b2610ce85",
           "key": "design-system",
           "moduleId": "modules/design-system",
           "name": "ujg-ed-design-system-modeling",
           "source": "sources/ed/skills/design-system/skill.md",
-          "sourceHash": "sha256:248600ed1312f8647b994d59da5f0df54b5de1854ee26dd4068ab5026cd16f26",
-          "specHash": "sha256:cf50c5a831f35de643ef910113c55e78235ca798b307fdc5db1a205dba6fe6d7"
+          "sourceHash": "sha256:32f4beea7ad532deeb88098f2d738ed150a2b547820d00afa1916e96a8de8474",
+          "specHash": "sha256:f6b77a460867aa9c3ff73e03026c33db58a03a1f38437054bd34f9aadef2d049"
         },
         {
           "artifactHash": "sha256:207f4bfe60791015cd3abfbcf7e86590593547c5a7f4dc3ae2a6c5a92890b4ee",
@@ -170,7 +170,7 @@
           "name": "ujg-ed-domain-model-design",
           "source": "sources/ed/skills/domain-model/skill.md",
           "sourceHash": "sha256:50eb75c2ad144259b7214e685e1b63606de6494198c27677fd9876373f2de956",
-          "specHash": "sha256:75c85eef3dd0201ad6d4fd2bc3738a00742451d6473337e2f6bde5ee2e81439e"
+          "specHash": "sha256:dff462241bc64427b2692e124d85e8b3050bd16e5c78f3cc8832a27966383be9"
         },
         {
           "artifactHash": "sha256:9599f4c30a8949dc2a8548607fbe9d4dc3b34ee6b1a9bce58ab6482893a47222",
@@ -179,7 +179,7 @@
           "name": "ujg-ed-domain-model-evaluation",
           "source": "sources/ed/skills/domain-model-evaluation/skill.md",
           "sourceHash": "sha256:ddbf680434d50519aaff77a1788d7e55c6580e5d852abdd2d924787b8f3ec3b1",
-          "specHash": "sha256:75c85eef3dd0201ad6d4fd2bc3738a00742451d6473337e2f6bde5ee2e81439e"
+          "specHash": "sha256:dff462241bc64427b2692e124d85e8b3050bd16e5c78f3cc8832a27966383be9"
         }
       ],
       "specRoot": "specs/ed"

--- a/packages/ujg-agent-pack/reviews/ed/design-system/latest.md
+++ b/packages/ujg-agent-pack/reviews/ed/design-system/latest.md
@@ -12,8 +12,8 @@ Spec URL: https://ujg.specs.openuji.org/ed/modules/design-system
 
 ## Review Inputs
 
-- Source hash: sha256:248600ed1312f8647b994d59da5f0df54b5de1854ee26dd4068ab5026cd16f26
-- Spec hash: sha256:cf50c5a831f35de643ef910113c55e78235ca798b307fdc5db1a205dba6fe6d7
+- Source hash: sha256:32f4beea7ad532deeb88098f2d738ed150a2b547820d00afa1916e96a8de8474
+- Spec hash: sha256:f6b77a460867aa9c3ff73e03026c33db58a03a1f38437054bd34f9aadef2d049
 
 ## Source Headings Likely Affected
 
@@ -25,6 +25,7 @@ Spec URL: https://ujg.specs.openuji.org/ed/modules/design-system
 - SurfaceRealization
 - Template, Slot, SlotBinding
 - TokenSource
+- DesignSystem
 - Navigation and forms
 - Checks before answering
 

--- a/packages/ujg-agent-pack/reviews/ed/domain-model-evaluation/latest.md
+++ b/packages/ujg-agent-pack/reviews/ed/domain-model-evaluation/latest.md
@@ -13,7 +13,7 @@ Spec URL: https://ujg.specs.openuji.org/ed/extensions/domain-model
 ## Review Inputs
 
 - Source hash: sha256:ddbf680434d50519aaff77a1788d7e55c6580e5d852abdd2d924787b8f3ec3b1
-- Spec hash: sha256:75c85eef3dd0201ad6d4fd2bc3738a00742451d6473337e2f6bde5ee2e81439e
+- Spec hash: sha256:dff462241bc64427b2692e124d85e8b3050bd16e5c78f3cc8832a27966383be9
 
 ## Source Headings Likely Affected
 

--- a/packages/ujg-agent-pack/reviews/ed/domain-model/latest.md
+++ b/packages/ujg-agent-pack/reviews/ed/domain-model/latest.md
@@ -13,7 +13,7 @@ Spec URL: https://ujg.specs.openuji.org/ed/extensions/domain-model
 ## Review Inputs
 
 - Source hash: sha256:50eb75c2ad144259b7214e685e1b63606de6494198c27677fd9876373f2de956
-- Spec hash: sha256:75c85eef3dd0201ad6d4fd2bc3738a00742451d6473337e2f6bde5ee2e81439e
+- Spec hash: sha256:dff462241bc64427b2692e124d85e8b3050bd16e5c78f3cc8832a27966383be9
 
 ## Source Headings Likely Affected
 

--- a/packages/ujg-agent-pack/reviews/ed/root/latest.md
+++ b/packages/ujg-agent-pack/reviews/ed/root/latest.md
@@ -13,7 +13,7 @@ Spec URL: https://ujg.specs.openuji.org/ed
 ## Review Inputs
 
 - Source hash: sha256:a70767c9f833acd3c26b0999e5934241279d2e28f30c858ca54def64da54b470
-- Spec hash: sha256:10d99802f110e6cf79bc67a11031bb4884c8717afc74bab621be640c01cd699c
+- Spec hash: sha256:0a850d13e5dce200b6aec3d452b08dbf6fcae3af6eb98c9719168f1b1a170d7f
 
 ## Source Headings Likely Affected
 

--- a/packages/ujg-agent-pack/reviews/registry.json
+++ b/packages/ujg-agent-pack/reviews/registry.json
@@ -10,22 +10,22 @@
     "ed/design-system": {
       "reportPath": "reviews/ed/design-system/latest.md",
       "skill": "design-system",
-      "sourceHash": "sha256:248600ed1312f8647b994d59da5f0df54b5de1854ee26dd4068ab5026cd16f26",
-      "specHash": "sha256:cf50c5a831f35de643ef910113c55e78235ca798b307fdc5db1a205dba6fe6d7",
+      "sourceHash": "sha256:32f4beea7ad532deeb88098f2d738ed150a2b547820d00afa1916e96a8de8474",
+      "specHash": "sha256:f6b77a460867aa9c3ff73e03026c33db58a03a1f38437054bd34f9aadef2d049",
       "target": "ed"
     },
     "ed/domain-model": {
       "reportPath": "reviews/ed/domain-model/latest.md",
       "skill": "domain-model",
       "sourceHash": "sha256:50eb75c2ad144259b7214e685e1b63606de6494198c27677fd9876373f2de956",
-      "specHash": "sha256:75c85eef3dd0201ad6d4fd2bc3738a00742451d6473337e2f6bde5ee2e81439e",
+      "specHash": "sha256:dff462241bc64427b2692e124d85e8b3050bd16e5c78f3cc8832a27966383be9",
       "target": "ed"
     },
     "ed/domain-model-evaluation": {
       "reportPath": "reviews/ed/domain-model-evaluation/latest.md",
       "skill": "domain-model-evaluation",
       "sourceHash": "sha256:ddbf680434d50519aaff77a1788d7e55c6580e5d852abdd2d924787b8f3ec3b1",
-      "specHash": "sha256:75c85eef3dd0201ad6d4fd2bc3738a00742451d6473337e2f6bde5ee2e81439e",
+      "specHash": "sha256:dff462241bc64427b2692e124d85e8b3050bd16e5c78f3cc8832a27966383be9",
       "target": "ed"
     },
     "ed/graph": {
@@ -53,7 +53,7 @@
       "reportPath": "reviews/ed/root/latest.md",
       "skill": "root",
       "sourceHash": "sha256:a70767c9f833acd3c26b0999e5934241279d2e28f30c858ca54def64da54b470",
-      "specHash": "sha256:10d99802f110e6cf79bc67a11031bb4884c8717afc74bab621be640c01cd699c",
+      "specHash": "sha256:0a850d13e5dce200b6aec3d452b08dbf6fcae3af6eb98c9719168f1b1a170d7f",
       "target": "ed"
     },
     "tr/1.0-rc1/core": {

--- a/packages/ujg-agent-pack/sources/ed/skills/design-system/skill.md
+++ b/packages/ujg-agent-pack/sources/ed/skills/design-system/skill.md
@@ -15,7 +15,7 @@ Correct layer order:
 ```text
 Surface -> graphNodeRef -> supported Graph node
 SurfaceRealization -> surfaceRef + componentRef/templateRef
-DesignSystem -> componentRefs/templateRefs/tokenSourceRefs/surfaceRealizationRefs
+DesignSystem -> tokenSourceRefs
 ```
 
 Graph defines topology.
@@ -52,9 +52,6 @@ Use only these common Design System properties:
 
 ```text
 tokenSourceRefs
-componentRefs
-templateRefs
-surfaceRealizationRefs
 surfaceRef
 componentRef
 templateRef
@@ -164,6 +161,14 @@ Slot bindings are presentation composition only. They do not imply traversal, st
 Use `TokenSource` only to reference a token source, package, manifest, or token set.
 
 Do not encode token values, CSS variables, aliases, themes, or style calculations unless the user explicitly asks for a project extension.
+
+## DesignSystem
+
+Use `DesignSystem` only as a token-source scope through `tokenSourceRefs`.
+
+Do not use `DesignSystem` as a component registry, template registry, or surface-realization registry.
+
+Consumers derive component, template, and realization inventories from `Component`, `Template`, `SurfaceRealization`, and `SlotBinding` nodes directly.
 
 ## Navigation and forms
 

--- a/packages/ujg-agent-pack/sources/ed/skills/domain-model/skill.md
+++ b/packages/ujg-agent-pack/sources/ed/skills/domain-model/skill.md
@@ -41,6 +41,9 @@ Produce the canonical payload for:
 UJGDocument.extensions["org.openuji.domain-model"]
 ```
 
+Do not add a payload-level extension version marker. Select the schema from the containing UJG
+document's specification family and namespace artifact route.
+
 Preserve unrelated UJG content and extensions.
 
 ## Semantic sources

--- a/specs/ed/extensions/domain-model/content-manifest.json
+++ b/specs/ed/extensions/domain-model/content-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
   "publishedAt": "2026-08-24T00:00:00.000Z",
-  "updatedAt": "2026-08-27T08:38:14.431Z",
-  "contentHash": "sha256:e0a1020fd564df7dbef7c562ff5417e264b71af87ddf62e22cb31fcff1ac423a"
+  "updatedAt": "2026-08-27T13:08:53.174Z",
+  "contentHash": "sha256:2286e160eecde9af59e4e1cc6210e1ab9b0ca26b0fcefaefa3a5557776c811e4"
 }

--- a/specs/ed/modules/design-system/content-manifest.json
+++ b/specs/ed/modules/design-system/content-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
   "publishedAt": "2026-06-09T10:00:00.000Z",
-  "updatedAt": "2026-07-13T10:43:07.864Z",
-  "contentHash": "sha256:f5a9630cc3c81e2927e58fbbe8c5ae8acb5495d1b2bb9a5034b0cfc9df28cb8c"
+  "updatedAt": "2026-08-27T12:57:35.000Z",
+  "contentHash": "sha256:6d3a74366d8da2e40d41b8f4d44f646abbf71d11400d3d986b31f5faf38279b3"
 }

--- a/specs/ed/modules/design-system/design-system.context.jsonld
+++ b/specs/ed/modules/design-system/design-system.context.jsonld
@@ -27,21 +27,6 @@
       "@type": "@id",
       "@container": "@set"
     },
-    "componentRefs": {
-      "@id": "ujgds:componentRefs",
-      "@type": "@id",
-      "@container": "@set"
-    },
-    "templateRefs": {
-      "@id": "ujgds:templateRefs",
-      "@type": "@id",
-      "@container": "@set"
-    },
-    "surfaceRealizationRefs": {
-      "@id": "ujgds:surfaceRealizationRefs",
-      "@type": "@id",
-      "@container": "@set"
-    },
     "componentRef": {
       "@id": "ujgds:componentRef",
       "@type": "@id"

--- a/specs/ed/modules/design-system/design-system.shape.ttl
+++ b/specs/ed/modules/design-system/design-system.shape.ttl
@@ -11,24 +11,6 @@ ujgdsshape:DesignSystemShape a sh:NodeShape ;
     sh:path ujgds:tokenSourceRefs ;
     sh:class ujgds:TokenSource ;
     sh:nodeKind sh:IRI ;
-  ] ;
-
-  sh:property [
-    sh:path ujgds:componentRefs ;
-    sh:class ujgds:Component ;
-    sh:nodeKind sh:IRI ;
-  ] ;
-
-  sh:property [
-    sh:path ujgds:templateRefs ;
-    sh:class ujgds:Template ;
-    sh:nodeKind sh:IRI ;
-  ] ;
-
-  sh:property [
-    sh:path ujgds:surfaceRealizationRefs ;
-    sh:class ujgds:SurfaceRealization ;
-    sh:nodeKind sh:IRI ;
   ] .
 
 ujgdsshape:TokenSourceShape a sh:NodeShape ;

--- a/specs/ed/modules/design-system/design-system.ttl
+++ b/specs/ed/modules/design-system/design-system.ttl
@@ -38,18 +38,6 @@ ujgds:tokenSourceRefs a owl:ObjectProperty ;
   rdfs:domain ujgds:DesignSystem ;
   rdfs:range ujgds:TokenSource .
 
-ujgds:componentRefs a owl:ObjectProperty ;
-  rdfs:domain ujgds:DesignSystem ;
-  rdfs:range ujgds:Component .
-
-ujgds:templateRefs a owl:ObjectProperty ;
-  rdfs:domain ujgds:DesignSystem ;
-  rdfs:range ujgds:Template .
-
-ujgds:surfaceRealizationRefs a owl:ObjectProperty ;
-  rdfs:domain ujgds:DesignSystem ;
-  rdfs:range ujgds:SurfaceRealization .
-
 ujgds:surfaceRef a owl:ObjectProperty ;
   rdfs:domain ujgds:SurfaceRealization ;
   rdfs:range ujgsurface:Surface .

--- a/specs/ed/modules/design-system/index.md
+++ b/specs/ed/modules/design-system/index.md
@@ -18,8 +18,7 @@ resolution, rendering behavior, or runtime semantics.
 
 ## Terminology
 
-- <dfn>DesignSystem</dfn>: A graph-native catalog or scope for design-system artifacts available to
-  realize surfaces.
+- <dfn>DesignSystem</dfn>: A graph-native design-system scope that references token sources.
 - <dfn>TokenSource</dfn>: An addressable token source, package, manifest, or token set. The internal
   token format is external to UJG.
 - <dfn>Component</dfn>: An addressable design-system artifact that can realize a surface or fill a
@@ -186,26 +185,18 @@ Example JSON node:
 
 ## DesignSystem {data-cop-concept="design-system"}
 
-A [=DesignSystem=] is a catalog or scope for token sources, components, templates, and surface
-realizations.
+A [=DesignSystem=] is a design-system scope that references token sources. Components, templates,
+and surface realizations are discovered from their own nodes and are not duplicated on the
+`DesignSystem`.
 
 ```mermaid
 classDiagram
   class TokenSource
-  class Component
-  class Template
-  class SurfaceRealization
   class DesignSystem {
     id
     tokenSourceRefs
-    componentRefs
-    templateRefs
-    surfaceRealizationRefs
   }
   DesignSystem --> "0..*" TokenSource : tokenSourceRefs
-  DesignSystem --> "0..*" Component : componentRefs
-  DesignSystem --> "0..*" Template : templateRefs
-  DesignSystem --> "0..*" SurfaceRealization : surfaceRealizationRefs
 ```
 
 Example JSON node:
@@ -214,10 +205,7 @@ Example JSON node:
 {
   "@type": "DesignSystem",
   "@id": "urn:ujg:design-system:shop",
-  "tokenSourceRefs": ["urn:ujg:tokens:brand"],
-  "componentRefs": ["urn:ujg:component:CheckoutForm"],
-  "templateRefs": ["urn:ujg:template:checkout-layout"],
-  "surfaceRealizationRefs": ["urn:ujg:realization:checkout-form"]
+  "tokenSourceRefs": ["urn:ujg:tokens:brand"]
 }
 ```
 
@@ -230,7 +218,7 @@ and does not make `Surface` depend on design-system artifacts.
 
 Design-system realization is expressed by `SurfaceRealization` nodes:
 
-- A `DesignSystem` MAY reference `SurfaceRealization` nodes through `surfaceRealizationRefs`.
+- A `DesignSystem` MAY reference `TokenSource` nodes through `tokenSourceRefs`.
 - A `SurfaceRealization` MUST reference exactly one `Surface`.
 - A `SurfaceRealization` MUST reference exactly one primary realization, either `componentRef` or
   `templateRef`.
@@ -239,25 +227,25 @@ Design-system realization is expressed by `SurfaceRealization` nodes:
   `slotBindingRefs`.
 - A `SlotBinding` MUST reference exactly one `Slot` and exactly one target.
 
-This shape allows multiple design systems to realize the same surface independently without changing
-the surface or assigning multiple surfaces to the same supported Graph node.
+This shape allows design-system token scopes to vary independently without changing the surface or
+assigning multiple surfaces to the same supported Graph node. Component, template, and realization
+inventories are derived from `Component`, `Template`, and `SurfaceRealization` nodes instead of
+being maintained as duplicate lists on `DesignSystem`.
 
-## DesignSystem Catalog
+## DesignSystem Scope
 
-A `DesignSystem` groups design-system artifacts and realizations available in a design-system
-context. It is not a renderer and does not define component internals, layout rules, or token
-syntax.
+A `DesignSystem` identifies a design-system context by referencing token sources. It is not a
+renderer, artifact inventory, realization registry, and does not define component internals, layout
+rules, or token syntax.
 
-The catalog properties are:
+The scope property is:
 
 - `tokenSourceRefs`: references zero or more `TokenSource` nodes.
-- `componentRefs`: references zero or more `Component` nodes.
-- `templateRefs`: references zero or more `Template` nodes.
-- `surfaceRealizationRefs`: references zero or more `SurfaceRealization` nodes.
 
 `TokenSource` identifies a token source, token package, token manifest, or token set. Individual
 token names, token paths, token groups, token values, aliases, and inheritance rules are outside this
-module.
+module. Consumers that need component, template, or realization inventories derive them from
+addressable design-system nodes and their references.
 
 ## Templates And Slots
 
@@ -427,16 +415,6 @@ This example assigns a state to a surface. It does not declare any design-system
       "graphNodeRef": "urn:state:cart"
     },
     {
-      "@id": "urn:ds:acme",
-      "@type": "DesignSystem",
-      "componentRefs": [
-        "urn:component:CartView"
-      ],
-      "surfaceRealizationRefs": [
-        "urn:realization:cart-web"
-      ]
-    },
-    {
       "@id": "urn:component:CartView",
       "@type": "Component"
     },
@@ -450,8 +428,8 @@ This example assigns a state to a surface. It does not declare any design-system
 }
 ```
 
-The surface remains unchanged. The design system owns the realization node that points to the
-surface.
+The surface remains unchanged. The realization node points to the surface directly, and clients can
+derive the used component by following the realization reference.
 
 ### Example C: Template Realization
 
@@ -486,19 +464,6 @@ surface.
       "@id": "urn:surface:submit-refund",
       "@type": "Surface",
       "graphNodeRef": "urn:transition:submit-refund"
-    },
-    {
-      "@id": "urn:ds:acme",
-      "@type": "DesignSystem",
-      "componentRefs": [
-        "urn:component:RefundForm"
-      ],
-      "templateRefs": [
-        "urn:template:FormShell"
-      ],
-      "surfaceRealizationRefs": [
-        "urn:realization:refund-form"
-      ]
     },
     {
       "@id": "urn:component:RefundForm",
@@ -718,16 +683,6 @@ The template declares slots. The realization binds those slots for this surface.
         "urn:binding:results",
         "urn:binding:preview"
       ]
-    },
-    {
-      "@id": "urn:ds:commerce",
-      "@type": "DesignSystem",
-      "templateRefs": [
-        "urn:template:ProductDiscovery"
-      ],
-      "surfaceRealizationRefs": [
-        "urn:realization:product-discovery"
-      ]
     }
   ]
 }
@@ -737,7 +692,7 @@ The composite state's surface is realized as a shell. Child containment comes fr
 referenced by `subjourneyId`. The child surfaces are placed into slots for presentation only; Graph
 remains the source of containment and traversal semantics.
 
-### Example E: Multiple Design Systems
+### Example E: Multiple Design-System Token Scopes
 
 ```json
 {
@@ -761,67 +716,52 @@ remains the source of containment and traversal semantics.
       "graphNodeRef": "urn:state:checkout"
     },
     {
-      "@id": "urn:component:WebCheckout",
+      "@id": "urn:component:Checkout",
       "@type": "Component"
     },
     {
-      "@id": "urn:component:KioskCheckout",
-      "@type": "Component"
-    },
-    {
-      "@id": "urn:component:CliCheckout",
-      "@type": "Component"
-    },
-    {
-      "@id": "urn:realization:checkout-web",
+      "@id": "urn:realization:checkout",
       "@type": "SurfaceRealization",
       "surfaceRef": "urn:surface:checkout",
-      "componentRef": "urn:component:WebCheckout"
+      "componentRef": "urn:component:Checkout"
     },
     {
-      "@id": "urn:realization:checkout-kiosk",
-      "@type": "SurfaceRealization",
-      "surfaceRef": "urn:surface:checkout",
-      "componentRef": "urn:component:KioskCheckout"
+      "@id": "urn:tokens:web",
+      "@type": "TokenSource"
     },
     {
-      "@id": "urn:realization:checkout-cli",
-      "@type": "SurfaceRealization",
-      "surfaceRef": "urn:surface:checkout",
-      "componentRef": "urn:component:CliCheckout"
+      "@id": "urn:tokens:kiosk",
+      "@type": "TokenSource"
+    },
+    {
+      "@id": "urn:tokens:cli",
+      "@type": "TokenSource"
     },
     {
       "@id": "urn:ds:web",
       "@type": "DesignSystem",
-      "componentRefs": [
-        "urn:component:WebCheckout"
-      ],
-      "surfaceRealizationRefs": [
-        "urn:realization:checkout-web"
+      "tokenSourceRefs": [
+        "urn:tokens:web"
       ]
     },
     {
       "@id": "urn:ds:kiosk",
       "@type": "DesignSystem",
-      "componentRefs": [
-        "urn:component:KioskCheckout"
-      ],
-      "surfaceRealizationRefs": [
-        "urn:realization:checkout-kiosk"
+      "tokenSourceRefs": [
+        "urn:tokens:kiosk"
       ]
     },
     {
       "@id": "urn:ds:cli",
       "@type": "DesignSystem",
-      "componentRefs": [
-        "urn:component:CliCheckout"
-      ],
-      "surfaceRealizationRefs": [
-        "urn:realization:checkout-cli"
+      "tokenSourceRefs": [
+        "urn:tokens:cli"
       ]
     }
   ]
 }
 ```
 
-The same surface can be realized by several design systems. The surface identity remains stable.
+Multiple design-system scopes can provide different token sources for the same surface and
+realization graph. Components, templates, and surface realizations remain discoverable from their own
+nodes rather than from duplicated `DesignSystem` lists.


### PR DESCRIPTION
## Summary

Clean up the ED Design System module so `DesignSystem` is only a token-source scope.

- Remove `componentRefs`, `templateRefs`, and `surfaceRealizationRefs` from the ED Design System ontology, JSON-LD context, SHACL shape, examples, and guidance.
- Update Design System prose/examples to derive component, template, and realization inventories from their own nodes instead of duplicating registry lists on `DesignSystem`.
- Regenerate ED agent-pack artifacts and accept updated ED review hashes.
- Restore domain-model skill guidance that payloads must not carry an independent extension version marker.
- Refresh affected content manifests.

## Validation

- `node scripts/content-manifests.js check`
- `pnpm agent-pack:check`
- `pnpm agent-pack:validate`
- `pnpm --filter @openuji/web exec speculator-lint ujg.workspace.json`
- `git diff --check`